### PR TITLE
Replace vector parsing with graph

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -60,8 +60,6 @@ This is an enum that signals information to the printer.
 * `StartIgnoringIndent` - Signal to the printer that it should stop using indentation.
 * `FinishIgnoringIndent` - Signal to the printer that it should start using indentation again.
 
-In the Rust implementation these exist directly on the `PrintItem` enum.
-
 ## Printer
 
 The printer takes the IR and outputs the final code. Its main responsibilities are:

--- a/packages/core/src/printer/preparePrintItems.ts
+++ b/packages/core/src/printer/preparePrintItems.ts
@@ -73,11 +73,13 @@ export function preparePrintItems(items: PrintItemIterable) {
         function addPath(condition: Condition, pathName: string, pathIterator: PrintItemIterable | undefined) {
             Object.defineProperty(condition, pathName, {
                 get: (() => {
-                    let pastIterator: PrintItemIterable | undefined;
+                    let pastIterator: PrintItem[] | undefined;
                     return () => {
                         if (pathIterator == null)
                             return;
-                        pastIterator = pastIterator || innerGetItemsAsArray(pathIterator);
+                        if (pastIterator != null)
+                            return pastIterator;
+                        pastIterator = innerGetItemsAsArray(pathIterator);
                         return pastIterator;
                     };
                 })(),

--- a/packages/core/src/printer/printWriteItems.ts
+++ b/packages/core/src/printer/printWriteItems.ts
@@ -7,13 +7,13 @@ export function printWriteItems(writeItems: any[], options: PrintOptions) {
     for (const item of writeItems) {
         if (typeof item === "string")
             finalItems.push(item);
+        else if (item instanceof Array)
+            finalItems.push(indentationText.repeat(item[0]));
         else if (item === 0)
-            finalItems.push(indentationText);
-        else if (item === 1)
             finalItems.push(options.newLineKind);
-        else if (item === 2)
+        else if (item === 1)
             finalItems.push("\t");
-        else if (item === 3)
+        else if (item === 2)
             finalItems.push(" ");
         else
             throw new Error(`Unhandled write item: ${item}`);

--- a/packages/core/wasm/src/get_js_write_items.rs
+++ b/packages/core/wasm/src/get_js_write_items.rs
@@ -4,11 +4,15 @@ use super::*;
 pub fn get_js_write_items<T>(write_items: T) -> Vec<JsValue> where T : Iterator<Item = WriteItem<JsString>> {
     write_items.into_iter().map(|item| -> JsValue {
         match item {
-            WriteItem::String(text) => Rc::try_unwrap(text).ok().unwrap().reference.into(),
-            WriteItem::Indent => js_sys::Number::from(0).into(),
-            WriteItem::NewLine => js_sys::Number::from(1).into(),
-            WriteItem::Tab => js_sys::Number::from(2).into(),
-            WriteItem::Space => js_sys::Number::from(3).into(),
+            WriteItem::String(container) => (&container.text.reference).into(),
+            WriteItem::Indent(times) => {
+                let indent_tuple = js_sys::Array::new();
+                indent_tuple.push(&js_sys::Number::from(times).into());
+                indent_tuple.into()
+            },
+            WriteItem::NewLine => js_sys::Number::from(0).into(),
+            WriteItem::Tab => js_sys::Number::from(1).into(),
+            WriteItem::Space => js_sys::Number::from(2).into(),
         }
     }).collect()
 }

--- a/packages/core/wasm/src/get_rust_print_items.rs
+++ b/packages/core/wasm/src/get_rust_print_items.rs
@@ -1,39 +1,40 @@
 use wasm_bindgen::*;
 use super::*;
 
-pub fn get_rust_print_items(print_items: Vec<JsValue>) -> Vec<PrintItem<JsString, JsInfo, JsCondition>> {
-    print_items.into_iter().map(|item| -> PrintItem<JsString, JsInfo, JsCondition> {
+pub fn get_rust_print_items(print_items: Vec<JsValue>) -> PrintItems<JsString, JsInfo, JsCondition> {
+    let mut items = PrintItems::new();
+    for item in print_items.into_iter() {
         if item.is_string() {
-            PrintItem::String(Rc::new(JsString {
-                reference: item.dyn_into::<js_sys::JsString>().ok().unwrap()
-            }))
+            let js_str = JsString::new(item.dyn_into::<js_sys::JsString>().ok().unwrap());
+            items.push_item(PrintItem::String(Rc::new(StringContainer::new(js_str))));
         } else if let Some(value) = item.dyn_ref::<js_sys::Number>() {
             let num: u8 = value.value_of() as u8;
-            match num {
-                0 => PrintItem::NewLine,
-                1 => PrintItem::Tab,
-                2 => PrintItem::PossibleNewLine,
-                3 => PrintItem::SpaceOrNewLine,
-                4 => PrintItem::ExpectNewLine,
-                5 => PrintItem::StartIndent,
-                6 => PrintItem::FinishIndent,
-                7 => PrintItem::StartNewLineGroup,
-                8 => PrintItem::FinishNewLineGroup,
-                9 => PrintItem::SingleIndent,
-                10 => PrintItem::StartIgnoringIndent,
-                11 => PrintItem::FinishIgnoringIndent,
+            items.push_item(PrintItem::Signal(match num {
+                0 => Signal::NewLine,
+                1 => Signal::Tab,
+                2 => Signal::PossibleNewLine,
+                3 => Signal::SpaceOrNewLine,
+                4 => Signal::ExpectNewLine,
+                5 => Signal::StartIndent,
+                6 => Signal::FinishIndent,
+                7 => Signal::StartNewLineGroup,
+                8 => Signal::FinishNewLineGroup,
+                9 => Signal::SingleIndent,
+                10 => Signal::StartIgnoringIndent,
+                11 => Signal::FinishIgnoringIndent,
                 _ => panic!("Not implemented value: {}", num),
-            }
+            }))
         } else {
             let value = item.unchecked_into::<JsConditionOrInfo>();
             let kind = value.kind();
             if kind == 0 {
-                PrintItem::Condition(Rc::new(value.unchecked_into::<JsCondition>()))
+                items.push_item(PrintItem::Condition(Rc::new(JsCondition::new(value.unchecked_into::<RawJsCondition>()))))
             } else if kind == 1 {
-                PrintItem::Info(Rc::new(value.unchecked_into::<JsInfo>()))
+                items.push_item(PrintItem::Info(Rc::new(value.unchecked_into::<JsInfo>())))
             } else {
                 panic!("Unknown print item kind: {}", kind);
             }
         }
-    }).collect()
+    }
+    items
 }

--- a/packages/core/wasm/src/get_write_items.rs
+++ b/packages/core/wasm/src/get_write_items.rs
@@ -6,7 +6,7 @@ pub fn get_write_items(print_items: Vec<JsValue>, max_width: u32, indent_width: 
     console_error_panic_hook::set_once();
 
     let rust_print_items = get_rust_print_items(print_items);
-    let write_items = dprint_core::get_write_items(rust_print_items, dprint_core::GetWriteItemsOptions {
+    let write_items = dprint_core::get_write_items(&rust_print_items, dprint_core::GetWriteItemsOptions {
         indent_width: indent_width,
         is_testing: is_testing,
         max_width: max_width

--- a/packages/core/wasm/src/js_types.rs
+++ b/packages/core/wasm/src/js_types.rs
@@ -139,11 +139,11 @@ impl ConditionRef<JsString, JsInfo, JsCondition> for JsCondition {
         }
     }
 
-    fn get_true_path(&self) -> Option<Rc<Vec<PrintItem<JsString, JsInfo, JsCondition>>>> {
-        self.true_path().map(|items| Rc::new(get_rust_print_items(items)))
+    fn get_true_path(&self) -> &Option<PrintItem<JsString, JsInfo, JsCondition>> {
+        &self.true_path().map(|items| PrintItem::Items(Rc::new(get_rust_print_items(items))))
     }
 
-    fn get_false_path(&self) -> Option<Rc<Vec<PrintItem<JsString, JsInfo, JsCondition>>>> {
-        self.false_path().map(|items| Rc::new(get_rust_print_items(items)))
+    fn get_false_path(&self) -> &Option<PrintItem<JsString, JsInfo, JsCondition>> {
+        &self.false_path().map(|items| PrintItem::Items(Rc::new(get_rust_print_items(items))))
     }
 }

--- a/packages/core/wasm/src/js_types.rs
+++ b/packages/core/wasm/src/js_types.rs
@@ -84,7 +84,7 @@ impl JsConditionResolverContext {
     }
 }
 
-impl InfoRef for JsInfo {
+impl InfoTrait for JsInfo {
     fn get_unique_id(&self) -> usize {
         self.id()
     }
@@ -108,7 +108,7 @@ impl StringRef for JsString {
     }
 }
 
-impl ConditionRef<JsString, JsInfo, JsCondition> for JsCondition {
+impl ConditionTrait<JsString, JsInfo, JsCondition> for JsCondition {
     fn get_unique_id(&self) -> usize {
         self.id()
     }

--- a/packages/core/wasm/src/js_types.rs
+++ b/packages/core/wasm/src/js_types.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::*;
 use dprint_core::*;
+use std::cell::RefCell;
 use super::*;
 
 #[wasm_bindgen]
@@ -22,23 +23,23 @@ extern "C" {
     pub fn id(this: &JsInfo) -> usize;
 
     // JsCondition
-    #[wasm_bindgen(js_name = JsCondition)]
-    pub type JsCondition;
+    #[wasm_bindgen(js_name = RawJsCondition)]
+    pub type RawJsCondition;
 
     #[wasm_bindgen(method, getter)]
-    pub fn name(this: &JsCondition) -> js_sys::JsString;
+    pub fn name(this: &RawJsCondition) -> js_sys::JsString;
 
     #[wasm_bindgen(method, getter)]
-    pub fn id(this: &JsCondition) -> usize;
+    pub fn id(this: &RawJsCondition) -> usize;
 
     #[wasm_bindgen(method)]
-    pub fn condition(this: &JsCondition, context: JsConditionResolverContext) -> Option<bool>;
+    pub fn condition(this: &RawJsCondition, context: JsConditionResolverContext) -> Option<bool>;
 
     #[wasm_bindgen(method, getter, js_name = truePath)]
-    pub fn true_path(this: &JsCondition) -> Option<Vec<JsValue>>;
+    pub fn true_path(this: &RawJsCondition) -> Option<Vec<JsValue>>;
 
     #[wasm_bindgen(method, getter, js_name = falsePath)]
-    pub fn false_path(this: &JsCondition) -> Option<Vec<JsValue>>;
+    pub fn false_path(this: &RawJsCondition) -> Option<Vec<JsValue>>;
 }
 
 #[wasm_bindgen]
@@ -46,8 +47,8 @@ extern "C" {
 pub struct JsWriterInfo {
     pub lineNumber: u32,
     pub columnNumber: u32,
-    pub indentLevel: u16,
-    pub lineStartIndentLevel: u16,
+    pub indentLevel: u8,
+    pub lineStartIndentLevel: u8,
     pub lineStartColumnNumber: u32,
 }
 
@@ -59,16 +60,43 @@ pub struct JsConditionResolverContext {
     pub writerInfo: JsWriterInfo,
 }
 
+pub struct JsCondition {
+    condition: RawJsCondition,
+    cached_true_path: RefCell<Option<Option<PrintItemPath<JsString, JsInfo, JsCondition>>>>,
+    cached_false_path: RefCell<Option<Option<PrintItemPath<JsString, JsInfo, JsCondition>>>>,
+}
+
+impl JsCondition {
+    pub fn new(condition: RawJsCondition) -> JsCondition {
+        JsCondition {
+            condition,
+            cached_true_path: RefCell::new(None),
+            cached_false_path: RefCell::new(None),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct JsString {
-    pub reference: js_sys::JsString
+    pub reference: js_sys::JsString,
+    cached_value: RefCell<Option<String>>,
+}
+
+impl JsString {
+    pub fn new(reference: js_sys::JsString) -> JsString {
+        JsString {
+            reference,
+            cached_value: RefCell::new(None),
+        }
+    }
 }
 
 #[wasm_bindgen]
 impl JsConditionResolverContext {
     /// Gets if a condition was true, false, or returns undefined when not yet resolved.
-    pub fn getResolvedCondition(&mut self, condition: &JsCondition) -> Option<bool> {
-        self.context.get_resolved_condition(condition)
+    pub fn getResolvedCondition(&mut self, condition: &RawJsCondition) -> Option<bool> {
+        let reference = ConditionReference::new("", condition.id());
+        self.context.get_resolved_condition(&reference)
     }
 
     /// Gets the writer info at a specified info or returns undefined when not yet resolved.
@@ -94,56 +122,73 @@ impl InfoTrait for JsInfo {
     }
 }
 
-impl StringRef for JsString {
+impl StringTrait for JsString {
     fn get_length(&self) -> usize {
         self.reference.length() as usize
     }
 
-    fn get_text(self) -> String {
-        self.reference.into()
-    }
+    fn get_text<'a>(&'a self) -> &'a str {
+        if self.cached_value.borrow().is_none() {
+            self.cached_value.borrow_mut().replace(self.reference.clone().into());
+        }
+        let cached_value = self.cached_value.borrow();
+        let value = cached_value.as_ref().unwrap();
 
-    fn get_text_clone(&self) -> String {
-        self.reference.clone().into()
+        // say the lifetime is the lifetime of the object (which is true)
+        unsafe { std::mem::transmute::<&str, &'a str>(value) }
     }
 }
 
 impl ConditionTrait<JsString, JsInfo, JsCondition> for JsCondition {
     fn get_unique_id(&self) -> usize {
-        self.id()
+        self.condition.id()
     }
 
     fn get_name(&self) -> &'static str {
         ""
     }
 
+    fn get_is_stored(&self) -> bool {
+        // Store all JS conditions for now. A performance improvement in the future
+        // would be to not store all these, but it's a very minor improvement.
+        true
+    }
+
     fn resolve(&self, context: &mut ConditionResolverContext<JsString, JsInfo, JsCondition>) -> Option<bool> {
-        unsafe {
-            // Force the object's lifetime to be 'static.
-            // This is unsafe, but wasm_bindgen can't deal with lifetimes, so we'll just tell it we know better.
-            let static_context = std::mem::transmute::<&mut ConditionResolverContext<JsString, JsInfo, JsCondition>, &mut ConditionResolverContext<'static, JsString, JsInfo, JsCondition>>(context);
+        // Force the object's lifetime to be 'static.
+        // This is unsafe, but wasm_bindgen can't deal with lifetimes, so we'll just tell it we know better.
+        let static_context = unsafe { std::mem::transmute::<&mut ConditionResolverContext<JsString, JsInfo, JsCondition>, &mut ConditionResolverContext<'static, JsString, JsInfo, JsCondition>>(context) };
 
-            let writer_info = JsWriterInfo {
-                lineNumber: context.writer_info.line_number,
-                columnNumber: context.writer_info.column_number,
-                indentLevel: context.writer_info.indent_level,
-                lineStartIndentLevel: context.writer_info.line_start_indent_level,
-                lineStartColumnNumber: context.writer_info.line_start_column_number,
-            };
-            let item = JsConditionResolverContext {
-                context: static_context,
-                writerInfo: writer_info,
-            };
+        let writer_info = JsWriterInfo {
+            lineNumber: context.writer_info.line_number,
+            columnNumber: context.writer_info.column_number,
+            indentLevel: context.writer_info.indent_level,
+            lineStartIndentLevel: context.writer_info.line_start_indent_level,
+            lineStartColumnNumber: context.writer_info.line_start_column_number,
+        };
+        let item = JsConditionResolverContext {
+            context: static_context,
+            writerInfo: writer_info,
+        };
 
-            self.condition(item)
+        self.condition.condition(item)
+    }
+
+    fn get_true_path(&self) -> Option<PrintItemPath<JsString, JsInfo, JsCondition>> {
+        if self.cached_true_path.borrow().is_none() {
+            let true_path = self.condition.true_path().map(|items| get_rust_print_items(items).into_rc_path());
+            self.cached_true_path.replace(true_path);
         }
+
+        self.cached_true_path.borrow().as_ref().map(|x| x.clone()).unwrap_or(None)
     }
 
-    fn get_true_path(&self) -> &Option<PrintItem<JsString, JsInfo, JsCondition>> {
-        &self.true_path().map(|items| PrintItem::Items(Rc::new(get_rust_print_items(items))))
-    }
+    fn get_false_path(&self) -> Option<PrintItemPath<JsString, JsInfo, JsCondition>> {
+        if self.cached_false_path.borrow().is_none() {
+            let false_path = self.condition.false_path().map(|items| get_rust_print_items(items).into_rc_path());
+            self.cached_false_path.replace(false_path);
+        }
 
-    fn get_false_path(&self) -> &Option<PrintItem<JsString, JsInfo, JsCondition>> {
-        &self.false_path().map(|items| PrintItem::Items(Rc::new(get_rust_print_items(items))))
+        self.cached_false_path.borrow().as_ref().map(|x| x.clone()).unwrap_or(None)
     }
 }

--- a/packages/rust-core/README.md
+++ b/packages/rust-core/README.md
@@ -114,18 +114,17 @@ pub fn format(expr: &ArrayLiteralExpression) -> String {
     let print_items = parse_node(Node::ArrayLiteralExpression(expr));
 
     // print them
-    dprint_core::print(print_items, GetWriteItemsOptions {
+    dprint_core::print(print_items, PrintOptions {
         indent_width: 4,
         max_width: 10,
-        is_testing: false,
         use_tabs: false,
         newline_kind: "\n",
-    });
+    })
 }
 
 // node parsing functions
 
-fn parse_node(node: Node) -> PrintItem {
+fn parse_node(node: Node) -> PrintItems {
     // in a real implementation this function would deal with surrounding comments
 
     match node {
@@ -134,71 +133,71 @@ fn parse_node(node: Node) -> PrintItem {
     }
 }
 
-fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItem {
-    let mut items: Vec<PrintItem> = Vec::new();
+fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_info = Info::new("start");
     let end_info = Info::new("end");
     let is_multiple_lines = create_is_multiple_lines_resolver(
         expr.position.clone(),
         expr.elements.iter().map(|e| e.position.clone()).collect(),
-        start_info.clone(),
-        end_info.clone()
+        start_info,
+        end_info
     );
 
-    items.push(start_info.into());
+    items.push_info(start_info);
 
-    items.push("[".into());
-    items.push(parser_helpers::if_true(
+    items.push_str("[");
+    items.extend(parser_helpers::if_true(
         "arrayStartNewLine",
         is_multiple_lines.clone(),
-        PrintItem::NewLine
+        Signal::NewLine.into()
     ));
 
-    let parsed_elements = Rc::new(parse_elements(&expr.elements, &is_multiple_lines));
-    items.push(Condition::new("indentIfMultipleLines", ConditionProperties {
+    let parsed_elements = parse_elements(&expr.elements, &is_multiple_lines).into_rc_path();
+    items.push_condition(Condition::new("indentIfMultipleLines", ConditionProperties {
         condition: Box::new(is_multiple_lines.clone()),
         true_path: Some(parser_helpers::with_indent(parsed_elements.clone().into())),
         false_path: Some(parsed_elements.into()),
     }).into());
 
-    items.push(parser_helpers::if_true(
+    items.extend(parser_helpers::if_true(
         "arrayEndNewLine",
         is_multiple_lines,
-        PrintItem::NewLine
+        Signal::NewLine.into()
     ));
-    items.push("]".into());
+    items.push_str("]");
 
-    items.push(end_info.into());
+    items.push_info(end_info);
 
-    return items.into();
+    return items;
 
     fn parse_elements(
         elements: &Vec<ArrayElement>,
         is_multiple_lines: &(impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static)
-    ) -> PrintItem {
-        let mut items = Vec::new();
+    ) -> PrintItems {
+        let mut items = PrintItems::new();
         let elements_len = elements.len();
 
         for (i, elem) in elements.iter().enumerate() {
-            items.push(parse_node(Node::ArrayElement(elem)));
+            items.extend(parse_node(Node::ArrayElement(elem)));
 
             if i < elements_len - 1 {
-                items.push(",".into());
-                items.push(parser_helpers::if_true_or(
+                items.push_str(",");
+                items.extend(parser_helpers::if_true_or(
                     "afterCommaSeparator",
                     is_multiple_lines.clone(),
-                    PrintItem::NewLine,
-                    PrintItem::SpaceOrNewLine
+                    Signal::NewLine.into(),
+                    Signal::SpaceOrNewLine.into()
                 ));
             }
         }
 
-        items.into()
+        items
     }
 }
 
-fn parse_array_element(element: &ArrayElement) -> PrintItem {
-    element.text.clone().into()
+fn parse_array_element(element: &ArrayElement) -> PrintItems {
+    (&element.text).into()
 }
 
 // helper functions

--- a/packages/rust-core/README.md
+++ b/packages/rust-core/README.md
@@ -154,11 +154,11 @@ fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItem {
         PrintItem::NewLine
     ));
 
-    let parsed_elements = parse_elements(&expr.elements, &is_multiple_lines);
+    let parsed_elements = Rc::new(parse_elements(&expr.elements, &is_multiple_lines));
     items.push(Condition::new("indentIfMultipleLines", ConditionProperties {
         condition: Box::new(is_multiple_lines.clone()),
-        true_path: Some(parser_helpers::with_indent(parsed_elements.clone())),
-        false_path: Some(parsed_elements),
+        true_path: Some(parser_helpers::with_indent(parsed_elements.clone().into())),
+        false_path: Some(parsed_elements.into()),
     }).into());
 
     items.push(parser_helpers::if_true(

--- a/packages/rust-core/README.md
+++ b/packages/rust-core/README.md
@@ -125,7 +125,7 @@ pub fn format(expr: &ArrayLiteralExpression) -> String {
 
 // node parsing functions
 
-fn parse_node(node: Node) -> Vec<PrintItem> {
+fn parse_node(node: Node) -> PrintItem {
     // in a real implementation this function would deal with surrounding comments
 
     match node {
@@ -134,7 +134,7 @@ fn parse_node(node: Node) -> Vec<PrintItem> {
     }
 }
 
-fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> Vec<PrintItem> {
+fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItem {
     let mut items: Vec<PrintItem> = Vec::new();
     let start_info = Info::new("start");
     let end_info = Info::new("end");
@@ -170,17 +170,17 @@ fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> Vec<PrintIte
 
     items.push(end_info.into());
 
-    return items;
+    return items.into();
 
     fn parse_elements(
         elements: &Vec<ArrayElement>,
         is_multiple_lines: &(impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static)
-    ) -> Vec<PrintItem> {
+    ) -> PrintItem {
         let mut items = Vec::new();
         let elements_len = elements.len();
 
         for (i, elem) in elements.iter().enumerate() {
-            items.extend(parse_node(Node::ArrayElement(elem)));
+            items.push(parse_node(Node::ArrayElement(elem)));
 
             if i < elements_len - 1 {
                 items.push(",".into());
@@ -193,12 +193,12 @@ fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> Vec<PrintIte
             }
         }
 
-        items
+        items.into()
     }
 }
 
-fn parse_array_element(element: &ArrayElement) -> Vec<PrintItem> {
-    vec![element.text.clone().into()]
+fn parse_array_element(element: &ArrayElement) -> PrintItem {
+    element.text.clone().into()
 }
 
 // helper functions
@@ -209,6 +209,8 @@ fn create_is_multiple_lines_resolver(
     start_info: Info,
     end_info: Info
 ) -> impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static {
+    // todo: this could be more efficient only only use references and avoid the clones
+    // I'm too lazy to update this sample, but it should help you get the idea.
     return move |condition_context: &mut ConditionResolverContext| {
         // no items, so format on the same line
         if child_positions.len() == 0 {

--- a/packages/rust-core/src/collections/fast_cell_map.rs
+++ b/packages/rust-core/src/collections/fast_cell_map.rs
@@ -1,0 +1,56 @@
+use std::cell::UnsafeCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// This fast cell map performs faster than a regular RefCell<HashMap<TKey, Rc<TValue>>
+/// because it avoids doing runtime checks on borrowing and mutation. This collection
+/// remains safe to the user because the value in the hashmap is stored in an Rc and
+/// only clones are returned. Additionally, the underlying collection is never exposed
+/// to the user.
+pub struct FastCellMap<TKey, TValue> {
+    value: UnsafeCell<HashMap<TKey, Rc<TValue>>>,
+}
+
+impl<TKey, TValue> FastCellMap<TKey, TValue> where TKey : std::cmp::Eq + std::hash::Hash + Clone {
+    pub fn new() -> FastCellMap<TKey, TValue> {
+        FastCellMap {
+            value: UnsafeCell::new(HashMap::new()),
+        }
+    }
+
+    pub fn replace_map(&mut self, new_map: HashMap<TKey, Rc<TValue>>) {
+        self.value = UnsafeCell::new(new_map);
+    }
+
+    pub fn contains_key(&self, key: &TKey) -> bool {
+        unsafe {
+            (*self.value.get()).contains_key(key)
+        }
+    }
+
+    pub fn insert(&self, key: TKey, value: Rc<TValue>) {
+        unsafe {
+            (*self.value.get()).insert(key, value);
+        }
+    }
+
+    pub fn remove(&self, key: &TKey) -> Option<Rc<TValue>> {
+        unsafe {
+            (*self.value.get()).remove(key)
+        }
+    }
+
+    pub fn clone_map(&self) -> HashMap<TKey, Rc<TValue>> {
+        unsafe {
+            (*self.value.get()).clone()
+        }
+    }
+
+    /// Used in the printer to panic if any item exists in the collection
+    /// at the end of printing.
+    pub fn get_any_item(&self) -> Option<Rc<TValue>> {
+        unsafe {
+            (*self.value.get()).iter().map(|(_, b)| b.clone()).next()
+        }
+    }
+}

--- a/packages/rust-core/src/collections/mod.rs
+++ b/packages/rust-core/src/collections/mod.rs
@@ -1,3 +1,5 @@
 mod graph_node;
+mod fast_cell_map;
 
 pub use graph_node::*;
+pub use fast_cell_map::*;

--- a/packages/rust-core/src/condition_resolvers.rs
+++ b/packages/rust-core/src/condition_resolvers.rs
@@ -16,12 +16,12 @@ pub fn is_hanging(condition_context: &mut ConditionResolverContext, start_info: 
     let resolved_end_info = get_resolved_end_info(condition_context, end_info)?;
     return Some(resolved_end_info.line_start_indent_level > resolved_start_info.line_start_indent_level);
 
-    fn get_resolved_end_info(condition_context: &mut ConditionResolverContext, end_info: &Option<Info>) -> Option<WriterInfo> {
+    fn get_resolved_end_info<'a>(condition_context: &'a ConditionResolverContext, end_info: &Option<Info>) -> Option<&'a WriterInfo> {
         if let Some(end_info) = end_info {
             condition_context.get_resolved_info(end_info)
         } else {
             // use the current condition position
-            Some(condition_context.writer_info.clone())
+            Some(&condition_context.writer_info)
         }
     }
 }

--- a/packages/rust-core/src/conditions.rs
+++ b/packages/rust-core/src/conditions.rs
@@ -1,19 +1,19 @@
 use super::print_items::*;
 use super::*;
 
-pub fn indent_if_start_of_line(elements: Vec<PrintItem>) -> Condition {
+pub fn indent_if_start_of_line(item: PrintItem) -> Condition {
     Condition::new("indentIfStartOfLine", ConditionProperties {
         condition: Box::new(|context| Some(condition_resolvers::is_start_of_new_line(&context))),
-        true_path: Some(parser_helpers::with_indent(elements.clone())),
-        false_path: Some(elements),
+        true_path: Some(parser_helpers::with_indent(item.clone())),
+        false_path: Some(item),
     })
 }
 
-pub fn with_indent_if_start_of_line_indented(elements: Vec<PrintItem>) -> Condition {
+pub fn with_indent_if_start_of_line_indented(item: PrintItem) -> Condition {
     Condition::new("withIndentIfStartOfLineIndented", ConditionProperties {
         condition: Box::new(|context| Some(context.writer_info.line_start_indent_level > context.writer_info.indent_level)),
-        true_path: parser_helpers::with_indent(elements.clone()).into(),
-        false_path: elements.into(),
+        true_path: parser_helpers::with_indent(item.clone()).into(),
+        false_path: item.into(),
     })
 }
 
@@ -32,8 +32,8 @@ pub fn new_line_if_hanging_space_otherwise(opts: NewLineIfHangingSpaceOtherwiseO
         condition: Box::new(move |context| {
             return condition_resolvers::is_hanging(context, &start_info, &end_info);
         }),
-        true_path: Some(vec![PrintItem::NewLine]),
-        false_path: Some(vec![space_char]),
+        true_path: Some(PrintItem::NewLine),
+        false_path: Some(space_char),
     })
 }
 
@@ -64,15 +64,15 @@ pub fn new_line_if_multiple_lines_space_or_new_line_otherwise(start_info: Info, 
 
             return Some(end_info.line_number > start_info.line_number);
         }),
-        true_path: Some(vec![PrintItem::NewLine]),
-        false_path: Some(vec![PrintItem::SpaceOrNewLine]),
+        true_path: Some(PrintItem::NewLine),
+        false_path: Some(PrintItem::SpaceOrNewLine),
     })
 }
 
 pub fn single_indent_if_start_of_line() -> Condition {
     Condition::new("singleIndentIfStartOfLine", ConditionProperties {
         condition: Box::new(|context| Some(condition_resolvers::is_start_of_new_line(context))),
-        true_path: Some(vec![PrintItem::SingleIndent]),
+        true_path: Some(PrintItem::SingleIndent),
         false_path: None
     })
 }

--- a/packages/rust-core/src/conditions.rs
+++ b/packages/rust-core/src/conditions.rs
@@ -39,6 +39,16 @@ pub fn new_line_if_hanging_space_otherwise(opts: NewLineIfHangingSpaceOtherwiseO
     })
 }
 
+pub fn new_line_if_hanging(start_info: Info, end_info: Option<Info>) -> Condition {
+    Condition::new("newlineIfHanging", ConditionProperties {
+        condition: Box::new(move |context| {
+            return condition_resolvers::is_hanging(context, &start_info, &end_info);
+        }),
+        true_path: Some(Signal::NewLine.into()),
+        false_path: None,
+    })
+}
+
 /// This condition can be used to force the printer to jump back to the point
 /// this condition exists at once the provided info is resolved.
 pub fn force_reevaluation_once_resolved(info: Info) -> Condition {

--- a/packages/rust-core/src/conditions.rs
+++ b/packages/rust-core/src/conditions.rs
@@ -1,9 +1,7 @@
-use std::rc::Rc;
 use super::print_items::*;
 use super::*;
 
-pub fn indent_if_start_of_line(item: PrintItem) -> Condition {
-    let item = Rc::new(item);
+pub fn indent_if_start_of_line(item: PrintItems) -> Condition {
     Condition::new("indentIfStartOfLine", ConditionProperties {
         condition: Box::new(|context| Some(condition_resolvers::is_start_of_new_line(&context))),
         true_path: Some(parser_helpers::with_indent(item.clone().into())),
@@ -11,8 +9,7 @@ pub fn indent_if_start_of_line(item: PrintItem) -> Condition {
     })
 }
 
-pub fn with_indent_if_start_of_line_indented(item: PrintItem) -> Condition {
-    let item = Rc::new(item);
+pub fn with_indent_if_start_of_line_indented(item: PrintItems) -> Condition {
     Condition::new("withIndentIfStartOfLineIndented", ConditionProperties {
         condition: Box::new(|context| Some(context.writer_info.line_start_indent_level > context.writer_info.indent_level)),
         true_path: Some(parser_helpers::with_indent(item.clone().into())),
@@ -23,7 +20,7 @@ pub fn with_indent_if_start_of_line_indented(item: PrintItem) -> Condition {
 pub struct NewLineIfHangingSpaceOtherwiseOptions {
     pub start_info: Info,
     pub end_info: Option<Info>,
-    pub space_char: Option<PrintItem>,
+    pub space_char: Option<PrintItems>,
 }
 
 pub fn new_line_if_hanging_space_otherwise(opts: NewLineIfHangingSpaceOtherwiseOptions) -> Condition {
@@ -35,7 +32,7 @@ pub fn new_line_if_hanging_space_otherwise(opts: NewLineIfHangingSpaceOtherwiseO
         condition: Box::new(move |context| {
             return condition_resolvers::is_hanging(context, &start_info, &end_info);
         }),
-        true_path: Some(PrintItem::NewLine),
+        true_path: Some(Signal::NewLine.into()),
         false_path: Some(space_char),
     })
 }
@@ -67,15 +64,15 @@ pub fn new_line_if_multiple_lines_space_or_new_line_otherwise(start_info: Info, 
 
             return Some(end_info.line_number > start_info.line_number);
         }),
-        true_path: Some(PrintItem::NewLine),
-        false_path: Some(PrintItem::SpaceOrNewLine),
+        true_path: Some(Signal::NewLine.into()),
+        false_path: Some(Signal::SpaceOrNewLine.into()),
     })
 }
 
 pub fn single_indent_if_start_of_line() -> Condition {
     Condition::new("singleIndentIfStartOfLine", ConditionProperties {
         condition: Box::new(|context| Some(condition_resolvers::is_start_of_new_line(context))),
-        true_path: Some(PrintItem::SingleIndent),
+        true_path: Some(Signal::SingleIndent.into()),
         false_path: None
     })
 }

--- a/packages/rust-core/src/conditions.rs
+++ b/packages/rust-core/src/conditions.rs
@@ -1,19 +1,22 @@
+use std::rc::Rc;
 use super::print_items::*;
 use super::*;
 
 pub fn indent_if_start_of_line(item: PrintItem) -> Condition {
+    let item = Rc::new(item);
     Condition::new("indentIfStartOfLine", ConditionProperties {
         condition: Box::new(|context| Some(condition_resolvers::is_start_of_new_line(&context))),
-        true_path: Some(parser_helpers::with_indent(item.clone())),
-        false_path: Some(item),
+        true_path: Some(parser_helpers::with_indent(item.clone().into())),
+        false_path: Some(item.into()),
     })
 }
 
 pub fn with_indent_if_start_of_line_indented(item: PrintItem) -> Condition {
+    let item = Rc::new(item);
     Condition::new("withIndentIfStartOfLineIndented", ConditionProperties {
         condition: Box::new(|context| Some(context.writer_info.line_start_indent_level > context.writer_info.indent_level)),
-        true_path: parser_helpers::with_indent(item.clone()).into(),
-        false_path: item.into(),
+        true_path: Some(parser_helpers::with_indent(item.clone().into())),
+        false_path: Some(item.into()),
     })
 }
 

--- a/packages/rust-core/src/conditions.rs
+++ b/packages/rust-core/src/conditions.rs
@@ -1,19 +1,21 @@
 use super::print_items::*;
 use super::*;
 
-pub fn indent_if_start_of_line(item: PrintItems) -> Condition {
+pub fn indent_if_start_of_line(items: PrintItems) -> Condition {
+    let rc_path = items.into_rc_path();
     Condition::new("indentIfStartOfLine", ConditionProperties {
         condition: Box::new(|context| Some(condition_resolvers::is_start_of_new_line(&context))),
-        true_path: Some(parser_helpers::with_indent(item.clone().into())),
-        false_path: Some(item.into()),
+        true_path: Some(parser_helpers::with_indent(rc_path.clone().into())),
+        false_path: Some(rc_path.into()),
     })
 }
 
-pub fn with_indent_if_start_of_line_indented(item: PrintItems) -> Condition {
+pub fn with_indent_if_start_of_line_indented(items: PrintItems) -> Condition {
+    let rc_path = items.into_rc_path();
     Condition::new("withIndentIfStartOfLineIndented", ConditionProperties {
         condition: Box::new(|context| Some(context.writer_info.line_start_indent_level > context.writer_info.indent_level)),
-        true_path: Some(parser_helpers::with_indent(item.clone().into())),
-        false_path: Some(item.into()),
+        true_path: Some(parser_helpers::with_indent(rc_path.clone().into())),
+        false_path: Some(rc_path.into()),
     })
 }
 

--- a/packages/rust-core/src/conditions.rs
+++ b/packages/rust-core/src/conditions.rs
@@ -60,7 +60,7 @@ pub fn new_line_if_multiple_lines_space_or_new_line_otherwise(start_info: Info, 
                 if let Some(end_info) = &end_info {
                     context.get_resolved_info(end_info)?
                 } else {
-                    context.writer_info.clone()
+                    &context.writer_info
                 }
             };
 

--- a/packages/rust-core/src/get_write_items.rs
+++ b/packages/rust-core/src/get_write_items.rs
@@ -2,7 +2,7 @@ use super::StringRef;
 use super::InfoRef;
 use super::ConditionRef;
 use super::printer::*;
-use super::PrintItem;
+use super::PrintItems;
 use super::WriteItem;
 
 /// Options for getting the write items.
@@ -18,10 +18,10 @@ pub struct GetWriteItemsOptions {
 }
 
 /// Gets write items from the print items.
-pub fn get_write_items<'a, TString, TInfo, TCondition>(
-    print_items: &'a Vec<PrintItem<TString, TInfo, TCondition>>,
+pub fn get_write_items<TString, TInfo, TCondition>(
+    print_items: &PrintItems<TString, TInfo, TCondition>,
     options: GetWriteItemsOptions
-) -> impl Iterator<Item = WriteItem<'a, TString>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    let printer = Printer::new(print_items, options);
+) -> impl Iterator<Item = WriteItem<TString>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    let printer = Printer::new(print_items.first_node.clone(), options);
     printer.print()
 }

--- a/packages/rust-core/src/get_write_items.rs
+++ b/packages/rust-core/src/get_write_items.rs
@@ -18,10 +18,10 @@ pub struct GetWriteItemsOptions {
 }
 
 /// Gets write items from the print items.
-pub fn get_write_items<TString, TInfo, TCondition>(
-    print_items: Vec<PrintItem<TString, TInfo, TCondition>>,
+pub fn get_write_items<'a, TString, TInfo, TCondition>(
+    print_items: &'a Vec<PrintItem<TString, TInfo, TCondition>>,
     options: GetWriteItemsOptions
-) -> impl Iterator<Item = WriteItem<TString>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+) -> impl Iterator<Item = WriteItem<'a, TString>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
     let printer = Printer::new(print_items, options);
     printer.print()
 }

--- a/packages/rust-core/src/get_write_items.rs
+++ b/packages/rust-core/src/get_write_items.rs
@@ -1,6 +1,6 @@
-use super::StringRef;
-use super::InfoRef;
-use super::ConditionRef;
+use super::StringTrait;
+use super::InfoTrait;
+use super::ConditionTrait;
 use super::printer::*;
 use super::PrintItems;
 use super::WriteItem;
@@ -21,7 +21,7 @@ pub struct GetWriteItemsOptions {
 pub fn get_write_items<TString, TInfo, TCondition>(
     print_items: &PrintItems<TString, TInfo, TCondition>,
     options: GetWriteItemsOptions
-) -> impl Iterator<Item = WriteItem<TString>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+) -> impl Iterator<Item = WriteItem<TString>> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     let printer = Printer::new(print_items.first_node.clone(), options);
     printer.print()
 }

--- a/packages/rust-core/src/parser_helpers.rs
+++ b/packages/rust-core/src/parser_helpers.rs
@@ -1,36 +1,36 @@
 use super::print_items::*;
 
-pub fn surround_with_new_lines(item: PrintItem) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(PrintItem::NewLine);
-    items.push(item);
-    items.push(PrintItem::NewLine);
-    items.into()
+pub fn surround_with_new_lines(item: PrintItems) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_signal(Signal::NewLine);
+    items.extend(item);
+    items.push_signal(Signal::NewLine);
+    items
 }
 
-pub fn with_indent(item: PrintItem) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(PrintItem::StartIndent);
-    items.push(item);
-    items.push(PrintItem::FinishIndent);
-    items.into()
+pub fn with_indent(item: PrintItems) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_signal(Signal::StartIndent);
+    items.extend(item);
+    items.push_signal(Signal::FinishIndent);
+    items
 }
 
-pub fn new_line_group(item: PrintItem) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(PrintItem::StartNewLineGroup);
-    items.push(item);
-    items.push(PrintItem::FinishNewLineGroup);
-    items.into()
+pub fn new_line_group(item: PrintItems) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_signal(Signal::StartNewLineGroup);
+    items.extend(item);
+    items.push_signal(Signal::FinishNewLineGroup);
+    items
 }
 
 pub fn if_true(
     name: &'static str,
     resolver: impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static,
-    true_item: PrintItem
-) -> PrintItem {
+    true_path: PrintItems
+) -> PrintItems {
     Condition::new(name, ConditionProperties {
-        true_path: Some(true_item),
+        true_path: Some(true_path),
         false_path: None,
         condition: Box::new(resolver.clone()),
     }).into()
@@ -39,18 +39,18 @@ pub fn if_true(
 pub fn if_true_or(
     name: &'static str,
     resolver: impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static,
-    true_item: PrintItem,
-    false_item: PrintItem
-) -> PrintItem {
+    true_path: PrintItems,
+    false_path: PrintItems
+) -> PrintItems {
     Condition::new(name, ConditionProperties {
-        true_path: Some(true_item),
-        false_path: Some(false_item),
+        true_path: Some(true_path),
+        false_path: Some(false_path),
         condition: Box::new(resolver.clone())
     }).into()
 }
 
-pub fn parse_raw_string(text: &str) -> PrintItem {
-    let mut items: Vec<PrintItem> = Vec::new();
+pub fn parse_raw_string(text: &str) -> PrintItems {
+    let mut items = PrintItems::new();
     let mut has_ignored_indent = false;
     let mut lines = text.lines().collect::<Vec<&str>>();
 
@@ -63,30 +63,30 @@ pub fn parse_raw_string(text: &str) -> PrintItem {
     for i in 0..lines.len() {
         if i > 0 {
             if !has_ignored_indent {
-                items.push(PrintItem::StartIgnoringIndent);
+                items.push_signal(Signal::StartIgnoringIndent);
                 has_ignored_indent = true;
             }
 
-            items.push(PrintItem::NewLine);
+            items.push_signal(Signal::NewLine);
         }
 
-        items.push(parse_line(&lines[i]));
+        items.extend(parse_line(&lines[i]));
     }
 
     if has_ignored_indent {
-        items.push(PrintItem::FinishIgnoringIndent);
+        items.push_signal(Signal::FinishIgnoringIndent);
     }
 
-    return items.into();
+    return items;
 
-    fn parse_line(line: &str) -> PrintItem {
-        let mut items: Vec<PrintItem> = Vec::new();
+    fn parse_line(line: &str) -> PrintItems {
+        let mut items = PrintItems::new();
         let parts = line.split("\t").collect::<Vec<&str>>();
         for i in 0..parts.len() {
             if i > 0 {
-                items.push(PrintItem::Tab);
+                items.push_signal(Signal::Tab);
             }
-            items.push(parts[i].into());
+            items.push_str(parts[i]);
         }
         items.into()
     }

--- a/packages/rust-core/src/parser_helpers.rs
+++ b/packages/rust-core/src/parser_helpers.rs
@@ -1,21 +1,27 @@
 use super::print_items::*;
 
-pub fn surround_with_new_lines(mut elements: Vec<PrintItem>) -> Vec<PrintItem> {
-    elements.insert(0, PrintItem::NewLine);
-    elements.push(PrintItem::NewLine);
-    elements
+pub fn surround_with_new_lines(item: PrintItem) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(PrintItem::NewLine);
+    items.push(item);
+    items.push(PrintItem::NewLine);
+    items.into()
 }
 
-pub fn with_indent(mut elements: Vec<PrintItem>) -> Vec<PrintItem> {
-    elements.insert(0, PrintItem::StartIndent);
-    elements.push(PrintItem::FinishIndent);
-    elements
+pub fn with_indent(item: PrintItem) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(PrintItem::StartIndent);
+    items.push(item);
+    items.push(PrintItem::FinishIndent);
+    items.into()
 }
 
-pub fn new_line_group(mut elements: Vec<PrintItem>) -> Vec<PrintItem> {
-    elements.insert(0, PrintItem::StartNewLineGroup);
-    elements.push(PrintItem::FinishNewLineGroup);
-    elements
+pub fn new_line_group(item: PrintItem) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(PrintItem::StartNewLineGroup);
+    items.push(item);
+    items.push(PrintItem::FinishNewLineGroup);
+    items.into()
 }
 
 pub fn if_true(
@@ -24,7 +30,7 @@ pub fn if_true(
     true_item: PrintItem
 ) -> PrintItem {
     Condition::new(name, ConditionProperties {
-        true_path: Some(vec![true_item]),
+        true_path: Some(true_item),
         false_path: None,
         condition: Box::new(resolver.clone()),
     }).into()
@@ -37,13 +43,13 @@ pub fn if_true_or(
     false_item: PrintItem
 ) -> PrintItem {
     Condition::new(name, ConditionProperties {
-        true_path: Some(vec![true_item]),
-        false_path: Some(vec![false_item]),
+        true_path: Some(true_item),
+        false_path: Some(false_item),
         condition: Box::new(resolver.clone())
     }).into()
 }
 
-pub fn parse_raw_string(text: &str) -> Vec<PrintItem> {
+pub fn parse_raw_string(text: &str) -> PrintItem {
     let mut items: Vec<PrintItem> = Vec::new();
     let mut has_ignored_indent = false;
     let mut lines = text.lines().collect::<Vec<&str>>();
@@ -64,16 +70,16 @@ pub fn parse_raw_string(text: &str) -> Vec<PrintItem> {
             items.push(PrintItem::NewLine);
         }
 
-        items.extend(parse_line(&lines[i]));
+        items.push(parse_line(&lines[i]));
     }
 
     if has_ignored_indent {
         items.push(PrintItem::FinishIgnoringIndent);
     }
 
-    return items;
+    return items.into();
 
-    fn parse_line(line: &str) -> Vec<PrintItem> {
+    fn parse_line(line: &str) -> PrintItem {
         let mut items: Vec<PrintItem> = Vec::new();
         let parts = line.split("\t").collect::<Vec<&str>>();
         for i in 0..parts.len() {
@@ -82,14 +88,6 @@ pub fn parse_raw_string(text: &str) -> Vec<PrintItem> {
             }
             items.push(parts[i].into());
         }
-        items
+        items.into()
     }
-}
-
-pub fn prepend_if_has_items(items: Vec<PrintItem>, item: PrintItem) -> Vec<PrintItem> {
-    let mut items = items;
-    if !items.is_empty() {
-        items.insert(0, item);
-    }
-    items
 }

--- a/packages/rust-core/src/print.rs
+++ b/packages/rust-core/src/print.rs
@@ -21,7 +21,8 @@ pub fn print<TString, TInfo, TCondition>(
     print_items: Vec<PrintItem<TString, TInfo, TCondition>>,
     options: PrintOptions
 ) -> String where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    let write_items = get_write_items(print_items, GetWriteItemsOptions {
+    let print_items = print_items.into_iter().map(|item| item.flatten()).collect();
+    let write_items = get_write_items(&print_items, GetWriteItemsOptions {
         indent_width: options.indent_width,
         max_width: options.max_width,
         is_testing: options.is_testing,

--- a/packages/rust-core/src/print.rs
+++ b/packages/rust-core/src/print.rs
@@ -10,21 +10,17 @@ pub struct PrintOptions {
     pub use_tabs: bool,
     /// The newline character to use when doing a new line.
     pub newline_kind: &'static str,
-    // Set this to true and the printer will do additional validation
-    // on input strings to ensure the printer is being used correctly.
-    // Setting this to true will make things much slower.
-    pub is_testing: bool,
 }
 
 /// Prints out the print items using the provided
 pub fn print<TString, TInfo, TCondition>(
     print_items: PrintItems<TString, TInfo, TCondition>,
     options: PrintOptions
-) -> String where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+) -> String where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     let write_items = get_write_items(&print_items, GetWriteItemsOptions {
         indent_width: options.indent_width,
         max_width: options.max_width,
-        is_testing: options.is_testing,
+        is_testing: false, // todo: remove
     });
 
     print_write_items(write_items, PrintWriteItemsOptions {

--- a/packages/rust-core/src/print.rs
+++ b/packages/rust-core/src/print.rs
@@ -18,10 +18,9 @@ pub struct PrintOptions {
 
 /// Prints out the print items using the provided
 pub fn print<TString, TInfo, TCondition>(
-    print_items: Vec<PrintItem<TString, TInfo, TCondition>>,
+    print_items: PrintItems<TString, TInfo, TCondition>,
     options: PrintOptions
 ) -> String where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    let print_items = print_items.into_iter().map(|item| item.flatten()).collect();
     let write_items = get_write_items(&print_items, GetWriteItemsOptions {
         indent_width: options.indent_width,
         max_width: options.max_width,

--- a/packages/rust-core/src/print_items.rs
+++ b/packages/rust-core/src/print_items.rs
@@ -528,7 +528,7 @@ impl<TString> StringContainer<TString> where TString : StringRef {
 pub struct WriterInfo {
     pub line_number: u32,
     pub column_number: u32,
-    pub indent_level: u16,
-    pub line_start_indent_level: u16,
+    pub indent_level: u8,
+    pub line_start_indent_level: u8,
     pub line_start_column_number: u32,
 }

--- a/packages/rust-core/src/print_items.rs
+++ b/packages/rust-core/src/print_items.rs
@@ -33,12 +33,14 @@ pub trait ConditionRef<TString, TInfo, TCondition> where TString : StringRef, TI
     fn get_unique_id(&self) -> usize;
     fn get_name(&self) -> &'static str;
     fn resolve(&self, context: &mut ConditionResolverContext<TString, TInfo, TCondition>) -> Option<bool>;
-    fn get_true_path(&self) -> Option<Rc<Vec<PrintItem<TString, TInfo, TCondition>>>>;
-    fn get_false_path(&self) -> Option<Rc<Vec<PrintItem<TString, TInfo, TCondition>>>>;
+    fn get_true_path(&self) -> &Option<PrintItem<TString, TInfo, TCondition>>;
+    fn get_false_path(&self) -> &Option<PrintItem<TString, TInfo, TCondition>>;
 }
 
 /// The different items the printer could encounter.
 pub enum PrintItem<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    // todo: an optimization for the future would be to not have Rc's in these and then to just use references in the printer
+    Items(Rc<Vec<PrintItem<TString, TInfo, TCondition>>>),
     String(Rc<TString>),
     Condition(Rc<TCondition>),
     Info(Rc<TInfo>),
@@ -71,22 +73,11 @@ pub enum PrintItem<TString = String, TInfo = Info, TCondition = Condition<TStrin
     FinishIgnoringIndent,
 }
 
-impl PrintItem {
-    // Gets if the print item is an item that signals information to the printer—not a string, condition, or info.
-    pub fn is_signal(&self) -> bool {
-        match self {
-            PrintItem::String(_) | PrintItem::Condition(_) | PrintItem::Info(_) => false,
-            PrintItem::NewLine | PrintItem::Tab | PrintItem::PossibleNewLine | PrintItem::SpaceOrNewLine | PrintItem::ExpectNewLine | PrintItem::StartIndent
-            | PrintItem::FinishIndent | PrintItem::StartNewLineGroup | PrintItem::FinishNewLineGroup | PrintItem::SingleIndent | PrintItem::StartIgnoringIndent
-            | PrintItem::FinishIgnoringIndent => true
-        }
-    }
-}
-
 // need to manually implement this for some reason instead of using #[derive(Clone)]
 impl<TString, TInfo, TCondition> Clone for PrintItem<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
     fn clone(&self) -> PrintItem<TString, TInfo, TCondition> {
         match self {
+            PrintItem::Items(items) => PrintItem::Items(items.clone()),
             PrintItem::String(text) => PrintItem::String(text.clone()),
             PrintItem::Condition(condition) => PrintItem::Condition(condition.clone()),
             PrintItem::Info(info) => PrintItem::Info(info.clone()),
@@ -115,6 +106,13 @@ impl<TInfo, TCondition> Into<PrintItem<String, TInfo, TCondition>> for &str wher
 impl<TInfo, TCondition> Into<PrintItem<String, TInfo, TCondition>> for String where TInfo : InfoRef, TCondition : ConditionRef<String, TInfo, TCondition> {
     fn into(self) -> PrintItem<String, TInfo, TCondition> {
         PrintItem::String(Rc::new(self))
+    }
+}
+
+// todo: This should use type parameters like the other ones, but it wasn't working for some reason
+impl Into<PrintItem> for Vec<PrintItem> {
+    fn into(self) -> PrintItem {
+        PrintItem::Items(Rc::new(self))
     }
 }
 
@@ -168,9 +166,9 @@ pub struct Condition<TString = String, TInfo = Info> where TString : StringRef, 
     /// The condition to resolve.
     pub condition: Rc<Box<ConditionResolver<TString, TInfo, Condition<TString, TInfo>>>>,
     /// The items to print when the condition is true.
-    pub true_path: Option<Rc<Vec<PrintItem<TString, TInfo, Condition<TString, TInfo>>>>>,
+    pub true_path: Option<PrintItem<TString, TInfo, Condition<TString, TInfo>>>,
     /// The items to print when the condition is false or undefined (not yet resolved).
-    pub false_path: Option<Rc<Vec<PrintItem<TString, TInfo, Condition<TString, TInfo>>>>>,
+    pub false_path: Option<PrintItem<TString, TInfo, Condition<TString, TInfo>>>,
 }
 
 // need to manually implement this for some reason instead of using #[derive(Clone)]
@@ -194,8 +192,8 @@ impl<TString, TInfo> Condition<TString, TInfo> where TString : StringRef, TInfo 
             id: CONDITION_COUNTER.fetch_add(1, Ordering::SeqCst),
             name,
             condition: Rc::new(properties.condition),
-            true_path: properties.true_path.map(|x| Rc::new(x)),
-            false_path: properties.false_path.map(|x| Rc::new(x)),
+            true_path: properties.true_path,
+            false_path: properties.false_path,
         }
     }
 }
@@ -213,12 +211,12 @@ impl<TString, TInfo> ConditionRef<TString, TInfo, Condition<TString, TInfo>> for
         (self.condition)(context)
     }
 
-    fn get_true_path(&self) -> Option<Rc<Vec<PrintItem<TString, TInfo, Self>>>> {
-        self.true_path.clone()
+    fn get_true_path(&self) -> &Option<PrintItem<TString, TInfo, Self>> {
+        &self.true_path
     }
 
-    fn get_false_path(&self) -> Option<Rc<Vec<PrintItem<TString, TInfo, Self>>>> {
-        self.false_path.clone()
+    fn get_false_path(&self) -> &Option<PrintItem<TString, TInfo, Self>> {
+        &self.false_path
     }
 }
 
@@ -233,9 +231,9 @@ pub struct ConditionProperties<TString = String, TInfo = Info> where TString : S
     /// The condition to resolve.
     pub condition: Box<ConditionResolver<TString, TInfo, Condition<TString, TInfo>>>,
     /// The items to print when the condition is true.
-    pub true_path: Option<Vec<PrintItem<TString, TInfo, Condition<TString, TInfo>>>>,
+    pub true_path: Option<PrintItem<TString, TInfo, Condition<TString, TInfo>>>,
     /// The items to print when the condition is false or undefined (not yet resolved).
-    pub false_path: Option<Vec<PrintItem<TString, TInfo, Condition<TString, TInfo>>>>,
+    pub false_path: Option<PrintItem<TString, TInfo, Condition<TString, TInfo>>>,
 }
 
 /// Function used to resolve a condition.

--- a/packages/rust-core/src/print_items.rs
+++ b/packages/rust-core/src/print_items.rs
@@ -1,6 +1,8 @@
 use super::printer::Printer;
 use std::rc::Rc;
+use std::cell::RefCell;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::mem;
 
 // Traits. This allows implementing these for Wasm objects.
 
@@ -33,18 +35,178 @@ pub trait ConditionRef<TString, TInfo, TCondition> where TString : StringRef, TI
     fn get_unique_id(&self) -> usize;
     fn get_name(&self) -> &'static str;
     fn resolve(&self, context: &mut ConditionResolverContext<TString, TInfo, TCondition>) -> Option<bool>;
-    fn get_true_path(&self) -> Option<&PrintItem<TString, TInfo, TCondition>>;
-    fn get_false_path(&self) -> Option<&PrintItem<TString, TInfo, TCondition>>;
+    fn get_true_path(&self) -> Option<Rc<RefCell<ConditionPath<TString, TInfo, TCondition>>>>;
+    fn get_false_path(&self) -> Option<Rc<RefCell<ConditionPath<TString, TInfo, TCondition>>>>;
+}
+
+pub struct PrintItems<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    pub(super) first_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
+    last_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
+}
+
+pub struct ConditionPath<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    pub(super) first_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
+    last_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
+    has_next_set: bool,
+}
+
+impl<TString, TInfo, TCondition> ConditionPath<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    pub(super) fn set_next_node_if_not_set(&mut self, next_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>) {
+        if self.has_next_set { return; }
+
+        if let Some(last_node) = self.last_node.as_ref().or(self.first_node.as_ref()) {
+            last_node.borrow_mut().set_next(next_node);
+        }
+
+        self.has_next_set = true;
+    }
+}
+
+
+impl<TString, TInfo, TCondition> PrintItems<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    pub fn new() -> PrintItems<TString, TInfo, TCondition> {
+        PrintItems {
+            first_node: None,
+            last_node: None,
+        }
+    }
+}
+
+impl PrintItems {
+    pub fn push(&mut self, node: PrintNode) {
+        let node = Rc::new(RefCell::new(node));
+        if let Some(first_node) = &self.first_node {
+            let new_last_node = node.get_last_next_or_self();
+            self.last_node.as_ref().unwrap_or(first_node).borrow_mut().set_next(Some(node));
+            self.last_node = Some(new_last_node);
+        } else {
+            self.first_node = Some(node);
+        }
+    }
+
+    pub fn extend(&mut self, items: PrintItems) {
+        if let Some(first_node) = &self.first_node {
+            self.last_node.as_ref().unwrap_or(first_node).borrow_mut().set_next(items.first_node.clone());
+            self.last_node = items.last_node.or(items.first_node.or(self.last_node.clone())); // todo: fix this
+        } else {
+            self.first_node = items.first_node;
+            self.last_node = items.last_node;
+        }
+    }
+
+    pub fn push_str(&mut self, item: &str) {
+        self.push(PrintNode::new(PrintItem::String(Rc::from(String::from(item)))));
+    }
+
+    pub fn push_condition(&mut self, condition: Condition) {
+        self.push(PrintNode::new(PrintItem::Condition(condition)));
+    }
+
+    pub fn push_info(&mut self, info: Info) {
+        self.push(PrintNode::new(PrintItem::Info(Rc::from(info))));
+    }
+
+    pub fn push_signal(&mut self, signal: Signal) {
+        self.push(PrintNode::new(PrintItem::Signal(Rc::new(signal))));
+    }
+}
+
+impl Clone for PrintItems {
+    fn clone(&self) -> PrintItems {
+        let mut items = PrintItems::new();
+        let mut next = self.first_node.clone();
+        while let Some(current) = next {
+            items.push(PrintNode {
+                item: current.borrow().item.clone(),
+                next: None,
+            });
+            next = current.borrow().next.clone();
+        }
+
+        items
+    }
+}
+
+impl Into<PrintItems> for &str {
+    fn into(self) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.push_str(self);
+        items
+    }
+}
+
+impl Into<PrintItems> for String {
+    fn into(self) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.push_str(&self);
+        items
+    }
+}
+
+impl Into<PrintItems> for Condition {
+    fn into(self) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.push_condition(self);
+        items
+    }
+}
+
+impl Into<PrintItems> for Signal {
+    fn into(self) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.push_signal(self);
+        items
+    }
+}
+
+pub struct PrintNode<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    pub(super) next: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
+    pub(super) item: PrintItem<TString, TInfo, TCondition>,
+}
+
+impl<TString, TInfo, TCondition> PrintNode<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    fn new(item: PrintItem<TString, TInfo, TCondition>) -> PrintNode<TString, TInfo, TCondition> {
+        PrintNode {
+            item,
+            next: None,
+        }
+    }
+
+    fn set_next(&mut self, new_next: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>) {
+        let past_next = mem::replace(&mut self.next, new_next.clone());
+
+        if let Some(past_next) = past_next {
+            if let Some(new_next) = new_next {
+                new_next.get_last_next_or_self().borrow_mut().set_next(Some(past_next));
+            }
+        }
+    }
+}
+
+trait RcPrintNodeGetLast<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    fn get_last_next_or_self(&self) -> Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>;
+}
+
+impl<TString, TInfo, TCondition> RcPrintNodeGetLast<TString, TInfo, TCondition> for Rc<RefCell<PrintNode<TString, TInfo, TCondition>>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    fn get_last_next_or_self(&self) -> Rc<RefCell<PrintNode<TString, TInfo, TCondition>>> {
+        let mut last = self.clone();
+        while let Some(next) = last.clone().borrow().next.clone() {
+            last = next;
+        }
+        return last;
+    }
 }
 
 /// The different items the printer could encounter.
+#[derive(Clone)]
 pub enum PrintItem<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    Items(Vec<PrintItem<TString, TInfo, TCondition>>),
-    String(TString),
-    Condition(TCondition),
-    Info(TInfo),
-    /// Useful for cloning in the parser code.
-    Rc(Rc<PrintItem<TString, TInfo, TCondition>>),
+    String(Rc<TString>),
+    Condition(TCondition), // no Rc because conditions shouldn't be shared since paths must be unique
+    Info(Rc<TInfo>),
+    Signal(Rc<Signal>),
+}
+
+pub enum Signal {
     /// Signal that a new line should occur based on the printer settings.
     NewLine,
     /// Signal that a tab should occur based on the printer settings.
@@ -74,76 +236,6 @@ pub enum PrintItem<TString = String, TInfo = Info, TCondition = Condition<TStrin
     FinishIgnoringIndent,
 }
 
-impl<TString, TInfo, TCondition> PrintItem<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    pub(super) fn flatten(self) -> PrintItem<TString, TInfo, TCondition> {
-        let capacity = get_capacity(&self);
-
-        // nothing to flatten
-        if capacity == 1 {
-            return self;
-        }
-        if let PrintItem::Items(items) = &self {
-            if items.len() == capacity {
-                return self;
-            }
-        }
-        // flatten
-        let mut flattened_items = Vec::with_capacity(capacity);
-        fill_items(self, &mut flattened_items);
-        return PrintItem::Items(flattened_items);
-
-        fn fill_items<TString, TInfo, TCondition>(
-            item: PrintItem<TString, TInfo, TCondition>,
-            flattened_items: &mut Vec<PrintItem<TString, TInfo, TCondition>>
-        ) where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-            match item {
-                PrintItem::Items(items) => {
-                    for item in items.into_iter() {
-                        fill_items(item, flattened_items);
-                    }
-                },
-                _ => flattened_items.push(item),
-            }
-        }
-
-        fn get_capacity<TString, TInfo, TCondition>(item: &PrintItem<TString, TInfo, TCondition>) -> usize where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-            match item {
-                PrintItem::Items(items) => {
-                    let mut capacity = 0;
-                    for item in items {
-                        capacity += get_capacity(item);
-                    }
-                    capacity
-                },
-                _ => 1
-            }
-        }
-    }
-
-    pub fn into_rc(self) -> Rc<PrintItem<TString, TInfo, TCondition>> {
-        Rc::new(self.flatten())
-    }
-}
-
-impl<TInfo, TCondition> Into<PrintItem<String, TInfo, TCondition>> for &str where TInfo : InfoRef, TCondition : ConditionRef<String, TInfo, TCondition> {
-    fn into(self) -> PrintItem<String, TInfo, TCondition> {
-        PrintItem::String(String::from(self))
-    }
-}
-
-impl<TInfo, TCondition> Into<PrintItem<String, TInfo, TCondition>> for String where TInfo : InfoRef, TCondition : ConditionRef<String, TInfo, TCondition> {
-    fn into(self) -> PrintItem<String, TInfo, TCondition> {
-        PrintItem::String(self)
-    }
-}
-
-// todo: This should use type parameters like the other ones, but it wasn't working for some reason
-impl Into<PrintItem> for Vec<PrintItem> {
-    fn into(self) -> PrintItem {
-        PrintItem::Items(self)
-    }
-}
-
 /// Can be used to get information at a certain location being printed. These
 /// can be resolved by providing the info object to a condition context's
 /// get_resolved_info(&info) method.
@@ -167,7 +259,7 @@ impl InfoRef for Info {
 
 impl<TString, TCondition> Into<PrintItem<TString, Info, TCondition>> for Info where TString : StringRef, TCondition : ConditionRef<TString, Info, TCondition> {
     fn into(self) -> PrintItem<TString, Info, TCondition> {
-        PrintItem::Info(self)
+        PrintItem::Info(Rc::new(self))
     }
 }
 
@@ -194,9 +286,9 @@ pub struct Condition<TString = String, TInfo = Info> where TString : StringRef, 
     /// The condition to resolve.
     pub condition: Rc<Box<ConditionResolver<TString, TInfo, Condition<TString, TInfo>>>>,
     /// The items to print when the condition is true.
-    pub true_path: Option<Rc<PrintItem<TString, TInfo, Condition<TString, TInfo>>>>,
+    pub true_path: Option<Rc<RefCell<ConditionPath<TString, TInfo, Condition<TString, TInfo>>>>>,
     /// The items to print when the condition is false or undefined (not yet resolved).
-    pub false_path: Option<Rc<PrintItem<TString, TInfo, Condition<TString, TInfo>>>>,
+    pub false_path: Option<Rc<RefCell<ConditionPath<TString, TInfo, Condition<TString, TInfo>>>>>,
 }
 
 // need to manually implement this for some reason instead of using #[derive(Clone)]
@@ -220,8 +312,16 @@ impl<TString, TInfo> Condition<TString, TInfo> where TString : StringRef, TInfo 
             id: CONDITION_COUNTER.fetch_add(1, Ordering::SeqCst),
             name,
             condition: Rc::new(properties.condition),
-            true_path: properties.true_path.map(|x| x.into_rc()),
-            false_path: properties.false_path.map(|x| x.into_rc()),
+            true_path: properties.true_path.map(|x| Rc::new(RefCell::new(ConditionPath {
+                first_node: x.first_node,
+                last_node: x.last_node,
+                has_next_set: false,
+            }))),
+            false_path: properties.false_path.map(|x| Rc::new(RefCell::new(ConditionPath {
+                first_node: x.first_node,
+                last_node: x.last_node,
+                has_next_set: false,
+            }))),
         }
     }
 }
@@ -239,18 +339,12 @@ impl<TString, TInfo> ConditionRef<TString, TInfo, Condition<TString, TInfo>> for
         (self.condition)(context)
     }
 
-    fn get_true_path(&self) -> Option<&PrintItem<TString, TInfo, Self>> {
-        match &self.true_path {
-            Some(path) => Some(&*path),
-            None => None
-        }
+    fn get_true_path(&self) -> Option<Rc<RefCell<ConditionPath<TString, TInfo, Condition<TString, TInfo>>>>> {
+        self.true_path.clone()
     }
 
-    fn get_false_path(&self) -> Option<&PrintItem<TString, TInfo, Self>> {
-        match &self.false_path {
-            Some(path) => Some(&*path),
-            None => None
-        }
+    fn get_false_path(&self) -> Option<Rc<RefCell<ConditionPath<TString, TInfo, Condition<TString, TInfo>>>>> {
+        self.false_path.clone()
     }
 }
 
@@ -260,34 +354,28 @@ impl<TString, TInfo> Into<PrintItem<TString, TInfo, Condition<TString, TInfo>>> 
     }
 }
 
-impl Into<PrintItem> for Rc<PrintItem> {
-    fn into(self) -> PrintItem {
-        PrintItem::Rc(self)
-    }
-}
-
 /// Properties for the condition.
 pub struct ConditionProperties<TString = String, TInfo = Info> where TString : StringRef, TInfo : InfoRef {
     /// The condition to resolve.
     pub condition: Box<ConditionResolver<TString, TInfo, Condition<TString, TInfo>>>,
     /// The items to print when the condition is true.
-    pub true_path: Option<PrintItem<TString, TInfo, Condition<TString, TInfo>>>,
+    pub true_path: Option<PrintItems<TString, TInfo, Condition<TString, TInfo>>>,
     /// The items to print when the condition is false or undefined (not yet resolved).
-    pub false_path: Option<PrintItem<TString, TInfo, Condition<TString, TInfo>>>,
+    pub false_path: Option<PrintItems<TString, TInfo, Condition<TString, TInfo>>>,
 }
 
 /// Function used to resolve a condition.
 pub type ConditionResolver<TString = String, TInfo = Info, TCondition = Condition> = dyn Fn(&mut ConditionResolverContext<TString, TInfo, TCondition>) -> Option<bool>; // todo: impl Fn(etc) -> etc + Clone + 'static; once supported
 
 /// Context used when resolving a condition.
-pub struct ConditionResolverContext<'a, 'b, TString = String, TInfo = Info, TCondition = Condition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    printer: &'a mut Printer<'b, TString, TInfo, TCondition>,
+pub struct ConditionResolverContext<'a, TString = String, TInfo = Info, TCondition = Condition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    printer: &'a mut Printer<TString, TInfo, TCondition>,
     /// Gets the writer info at the condition's location.
     pub writer_info: WriterInfo,
 }
 
-impl<'a, 'b, TString, TInfo, TCondition> ConditionResolverContext<'a, 'b, TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    pub fn new(printer: &'a mut Printer<'b, TString, TInfo, TCondition>) -> Self {
+impl<'a, TString, TInfo, TCondition> ConditionResolverContext<'a, TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    pub fn new(printer: &'a mut Printer<TString, TInfo, TCondition>) -> Self {
         let writer_info = printer.get_writer_info();
         ConditionResolverContext {
             printer,

--- a/packages/rust-core/src/print_items.rs
+++ b/packages/rust-core/src/print_items.rs
@@ -4,15 +4,15 @@ use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::mem;
 
-// Traits. This allows implementing these for Wasm objects.
+/* Traits -- This allows implementing these for Wasm objects. */
 
-pub trait StringRef {
+pub trait StringTrait {
     fn get_length(&self) -> usize;
     fn get_text<'a>(&'a self) -> &'a str;
     fn get_text_clone(&self) -> String;
 }
 
-impl StringRef for String {
+impl StringTrait for String {
     fn get_length(&self) -> usize {
         self.chars().count()
     }
@@ -26,12 +26,12 @@ impl StringRef for String {
     }
 }
 
-pub trait InfoRef {
+pub trait InfoTrait {
     fn get_unique_id(&self) -> usize;
     fn get_name(&self) -> &'static str;
 }
 
-pub trait ConditionRef<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+pub trait ConditionTrait<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     fn get_unique_id(&self) -> usize;
     fn get_is_stored(&self) -> bool;
     fn get_name(&self) -> &'static str;
@@ -40,12 +40,14 @@ pub trait ConditionRef<TString, TInfo, TCondition> where TString : StringRef, TI
     fn get_false_path(&self) -> Option<PrintItemPath<TString, TInfo, TCondition>>;
 }
 
-pub struct PrintItems<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+/** Print Items */
+
+pub struct PrintItems<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     pub(super) first_node: Option<PrintItemPath<TString, TInfo, TCondition>>,
     last_node: Option<PrintItemPath<TString, TInfo, TCondition>>,
 }
 
-impl<TString, TInfo, TCondition> PrintItems<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+impl<TString, TInfo, TCondition> PrintItems<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     pub fn new() -> PrintItems<TString, TInfo, TCondition> {
         PrintItems {
             first_node: None,
@@ -197,6 +199,14 @@ impl Into<PrintItems> for String {
     }
 }
 
+impl Into<PrintItems> for &String {
+    fn into(self) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.push_str(self);
+        items
+    }
+}
+
 impl Into<PrintItems> for Condition {
     fn into(self) -> PrintItems {
         let mut items = PrintItems::new();
@@ -223,12 +233,14 @@ impl Into<PrintItems> for Option<PrintItemPath> {
     }
 }
 
-pub struct PrintNode<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+/** Print Node */
+
+pub struct PrintNode<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     pub(super) next: Option<PrintItemPath<TString, TInfo, TCondition>>,
     pub(super) item: PrintItem<TString, TInfo, TCondition>,
 }
 
-impl<TString, TInfo, TCondition> Drop for PrintNode<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+impl<TString, TInfo, TCondition> Drop for PrintNode<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     fn drop(&mut self) {
         let mut next = mem::replace(&mut self.next, None);
 
@@ -246,7 +258,7 @@ impl<TString, TInfo, TCondition> Drop for PrintNode<TString, TInfo, TCondition> 
     }
 }
 
-impl<TString, TInfo, TCondition> PrintNode<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+impl<TString, TInfo, TCondition> PrintNode<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     fn new(item: PrintItem<TString, TInfo, TCondition>) -> PrintNode<TString, TInfo, TCondition> {
         PrintNode {
             item,
@@ -265,7 +277,7 @@ impl<TString, TInfo, TCondition> PrintNode<TString, TInfo, TCondition> where TSt
     }
 }
 
-pub trait PrintItemPathExtensions<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+pub trait PrintItemPathExtensions<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     fn get_item(&self) -> PrintItem<TString, TInfo, TCondition>;
     fn get_next(&self) -> Option<PrintItemPath<TString, TInfo, TCondition>>;
     fn has_next(&self) -> bool;
@@ -273,7 +285,7 @@ pub trait PrintItemPathExtensions<TString, TInfo, TCondition> where TString : St
     fn get_last_next_or_self(&self) -> PrintItemPath<TString, TInfo, TCondition>;
 }
 
-impl<TString, TInfo, TCondition> PrintItemPathExtensions<TString, TInfo, TCondition> for PrintItemPath<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+impl<TString, TInfo, TCondition> PrintItemPathExtensions<TString, TInfo, TCondition> for PrintItemPath<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     #[inline]
     fn get_item(&self) -> PrintItem<TString, TInfo, TCondition> {
         unsafe {
@@ -314,8 +326,10 @@ impl<TString, TInfo, TCondition> PrintItemPathExtensions<TString, TInfo, TCondit
 
 pub type PrintItemPath<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> = Rc<UnsafeCell<PrintNode<TString, TInfo, TCondition>>>;
 
+/* Print item and kinds */
+
 /// The different items the printer could encounter.
-pub enum PrintItem<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+pub enum PrintItem<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     String(Rc<StringContainer<TString>>),
     Condition(Rc<TCondition>),
     Info(Rc<TInfo>),
@@ -323,7 +337,7 @@ pub enum PrintItem<TString = String, TInfo = Info, TCondition = Condition<TStrin
     RcPath(PrintItemPath<TString, TInfo, TCondition>),
 }
 
-impl<TString, TInfo, TCondition> Clone for PrintItem<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+impl<TString, TInfo, TCondition> Clone for PrintItem<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     fn clone(&self) -> PrintItem<TString, TInfo, TCondition> {
         match self {
             PrintItem::String(text) => PrintItem::String(text.clone()),
@@ -369,7 +383,7 @@ pub enum Signal {
 /// Can be used to get information at a certain location being printed. These
 /// can be resolved by providing the info object to a condition context's
 /// get_resolved_info(&info) method.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Copy, Debug)]
 pub struct Info {
     /// Unique identifier.
     id: usize,
@@ -377,7 +391,7 @@ pub struct Info {
     name: &'static str,
 }
 
-impl InfoRef for Info {
+impl InfoTrait for Info {
     fn get_unique_id(&self) -> usize {
         self.id
     }
@@ -402,7 +416,7 @@ impl Info {
 ///
 /// These conditions are extremely flexible and can even be resolved based on
 /// information found later on in the file.
-pub struct Condition<TString = String, TInfo = Info> where TString : StringRef, TInfo : InfoRef {
+pub struct Condition<TString = String, TInfo = Info> where TString : StringTrait, TInfo : InfoTrait {
     /// Unique identifier.
     id: usize,
     /// Name for debugging purposes.
@@ -432,7 +446,7 @@ impl Clone for Condition {
 
 static CONDITION_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-impl<TString, TInfo> Condition<TString, TInfo> where TString : StringRef, TInfo : InfoRef {
+impl<TString, TInfo> Condition<TString, TInfo> where TString : StringTrait, TInfo : InfoTrait {
     pub fn new(name: &'static str, properties: ConditionProperties<TString, TInfo>) -> Condition<TString, TInfo> {
         Condition {
             id: CONDITION_COUNTER.fetch_add(1, Ordering::SeqCst),
@@ -459,7 +473,7 @@ pub struct ConditionReference {
     pub(super) id: usize,
 }
 
-impl<TString, TInfo> ConditionRef<TString, TInfo, Condition<TString, TInfo>> for Condition<TString, TInfo> where TString : StringRef, TInfo : InfoRef {
+impl<TString, TInfo> ConditionTrait<TString, TInfo, Condition<TString, TInfo>> for Condition<TString, TInfo> where TString : StringTrait, TInfo : InfoTrait {
     #[inline]
     fn get_unique_id(&self) -> usize {
         self.id
@@ -492,7 +506,7 @@ impl<TString, TInfo> ConditionRef<TString, TInfo, Condition<TString, TInfo>> for
 }
 
 /// Properties for the condition.
-pub struct ConditionProperties<TString = String, TInfo = Info> where TString : StringRef, TInfo : InfoRef {
+pub struct ConditionProperties<TString = String, TInfo = Info> where TString : StringTrait, TInfo : InfoTrait {
     /// The condition to resolve.
     pub condition: Box<ConditionResolver<TString, TInfo, Condition<TString, TInfo>>>,
     /// The items to print when the condition is true.
@@ -505,13 +519,13 @@ pub struct ConditionProperties<TString = String, TInfo = Info> where TString : S
 pub type ConditionResolver<TString = String, TInfo = Info, TCondition = Condition> = dyn Fn(&mut ConditionResolverContext<TString, TInfo, TCondition>) -> Option<bool>; // todo: impl Fn(etc) -> etc + Clone + 'static; once supported
 
 /// Context used when resolving a condition.
-pub struct ConditionResolverContext<'a, TString = String, TInfo = Info, TCondition = Condition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+pub struct ConditionResolverContext<'a, TString = String, TInfo = Info, TCondition = Condition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     printer: &'a mut Printer<TString, TInfo, TCondition>,
     /// Gets the writer info at the condition's location.
     pub writer_info: WriterInfo,
 }
 
-impl<'a, TString, TInfo, TCondition> ConditionResolverContext<'a, TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+impl<'a, TString, TInfo, TCondition> ConditionResolverContext<'a, TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     pub fn new(printer: &'a mut Printer<TString, TInfo, TCondition>) -> Self {
         let writer_info = printer.get_writer_info();
         ConditionResolverContext {
@@ -534,7 +548,7 @@ impl<'a, TString, TInfo, TCondition> ConditionResolverContext<'a, TString, TInfo
 
 /// A container that holds the string's value and character count.
 #[derive(Clone)]
-pub struct StringContainer<TString> where TString : StringRef {
+pub struct StringContainer<TString> where TString : StringTrait {
     /// The string value.
     pub text: TString,
     /// The cached character count.
@@ -542,7 +556,7 @@ pub struct StringContainer<TString> where TString : StringRef {
     pub(super) char_count: u32,
 }
 
-impl<TString> StringContainer<TString> where TString : StringRef {
+impl<TString> StringContainer<TString> where TString : StringTrait {
     /// Creates a new string container.
     pub(super) fn new(text: TString) -> StringContainer<TString> {
         let char_count = text.get_length() as u32;

--- a/packages/rust-core/src/print_items.rs
+++ b/packages/rust-core/src/print_items.rs
@@ -35,33 +35,14 @@ pub trait ConditionRef<TString, TInfo, TCondition> where TString : StringRef, TI
     fn get_unique_id(&self) -> usize;
     fn get_name(&self) -> &'static str;
     fn resolve(&self, context: &mut ConditionResolverContext<TString, TInfo, TCondition>) -> Option<bool>;
-    fn get_true_path(&self) -> Option<Rc<RefCell<ConditionPath<TString, TInfo, TCondition>>>>;
-    fn get_false_path(&self) -> Option<Rc<RefCell<ConditionPath<TString, TInfo, TCondition>>>>;
+    fn get_true_path(&self) -> Option<PrintItemPath<TString, TInfo, TCondition>>;
+    fn get_false_path(&self) -> Option<PrintItemPath<TString, TInfo, TCondition>>;
 }
 
 pub struct PrintItems<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    pub(super) first_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
-    last_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
+    pub(super) first_node: Option<PrintItemPath<TString, TInfo, TCondition>>,
+    last_node: Option<PrintItemPath<TString, TInfo, TCondition>>,
 }
-
-pub struct ConditionPath<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    pub(super) first_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
-    last_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
-    has_next_set: bool,
-}
-
-impl<TString, TInfo, TCondition> ConditionPath<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    pub(super) fn set_next_node_if_not_set(&mut self, next_node: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>) {
-        if self.has_next_set { return; }
-
-        if let Some(last_node) = self.last_node.as_ref().or(self.first_node.as_ref()) {
-            last_node.borrow_mut().set_next(next_node);
-        }
-
-        self.has_next_set = true;
-    }
-}
-
 
 impl<TString, TInfo, TCondition> PrintItems<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
     pub fn new() -> PrintItems<TString, TInfo, TCondition> {
@@ -70,13 +51,13 @@ impl<TString, TInfo, TCondition> PrintItems<TString, TInfo, TCondition> where TS
             last_node: None,
         }
     }
+
+    pub fn into_rc_path(self) -> Option<PrintItemPath<TString, TInfo, TCondition>> {
+        self.first_node
+    }
 }
 
 impl PrintItems {
-    pub fn push(&mut self, item: PrintItem) {
-        self.push_node(PrintNode::new(item));
-    }
-
     pub fn extend(&mut self, items: PrintItems) {
         if let Some(first_node) = &self.first_node {
             self.last_node.as_ref().unwrap_or(first_node).borrow_mut().set_next(items.first_node.clone());
@@ -88,26 +69,28 @@ impl PrintItems {
     }
 
     pub fn push_str(&mut self, item: &str) {
-        self.push_node(PrintNode::new(PrintItem::String(Rc::from(String::from(item)))));
+        self.push(PrintItem::String(Rc::from(String::from(item))));
     }
 
     pub fn push_condition(&mut self, condition: Condition) {
-        self.push_node(PrintNode::new(PrintItem::Condition(condition)));
+        self.push(PrintItem::Condition(Rc::from(condition)));
     }
 
     pub fn push_info(&mut self, info: Info) {
-        self.push_node(PrintNode::new(PrintItem::Info(Rc::from(info))));
+        self.push(PrintItem::Info(Rc::from(info)));
     }
 
     pub fn push_signal(&mut self, signal: Signal) {
-        self.push_node(PrintNode::new(PrintItem::Signal(signal)));
+        self.push(PrintItem::Signal(signal));
     }
 
-    pub(super) fn push_node(&mut self, node: PrintNode) {
-        self.push_rc_node(Rc::new(RefCell::new(node)));
+    pub fn push_path(&mut self, path: PrintItemPath) {
+        self.push(PrintItem::RcPath(path))
     }
 
-    pub(super) fn push_rc_node(&mut self, node: Rc<RefCell<PrintNode>>) {
+    #[inline]
+    pub fn push(&mut self, item: PrintItem) {
+        let node = Rc::new(RefCell::new(PrintNode::new(item)));
         if let Some(first_node) = &self.first_node {
             let new_last_node = node.get_last_next_or_self();
             self.last_node.as_ref().unwrap_or(first_node).borrow_mut().set_next(Some(node));
@@ -124,25 +107,33 @@ impl PrintItems {
         self.first_node.is_none()
     }
 
-    // todo: only compile when debugging
-    pub fn get_as_text(self) -> String {
-        return get_items_as_text(self, String::from(""));
+    // todo: only compile when debugging and clean this up
+    pub fn get_as_text(&self) -> String {
+        return if let Some(first_node) = &self.first_node {
+            get_items_as_text(first_node.clone(), String::from(""))
+        } else {
+            String::new()
+        };
 
-        fn get_items_as_text(items: PrintItems, indent_text: String) -> String {
+        fn get_items_as_text(items: PrintItemPath, indent_text: String) -> String {
             let mut text = String::new();
-            for item in items.into_iter() {
+            for item in PrintItemsIterator::new(items) {
                 match item {
                     PrintItem::Signal(signal) => text.push_str(&get_line(format!("Signal::{:?}", signal), &indent_text)),
                     PrintItem::Info(info) => text.push_str(&get_line(format!("Info: {}", info.name), &indent_text)),
                     PrintItem::Condition(condition) => {
                         text.push_str(&get_line(format!("Condition: {}", condition.name), &indent_text));
-                        let true_items = condition.get_true_items();
-                        if !true_items.is_empty() {
+                        if let Some(true_path) = condition.get_true_path() {
                             text.push_str(&get_line(String::from("  true:"), &indent_text));
-                            text.push_str(&get_items_as_text(true_items, format!("{}    ", &indent_text)));
+                            text.push_str(&get_items_as_text(true_path.clone(), format!("{}    ", &indent_text)));
+                        }
+                        if let Some(false_path) = condition.get_false_path() {
+                            text.push_str(&get_line(String::from("  false:"), &indent_text));
+                            text.push_str(&get_items_as_text(false_path.clone(), format!("{}    ", &indent_text)));
                         }
                     },
                     PrintItem::String(str_text) => text.push_str(&get_line(str_text.to_string(), &indent_text)),
+                    PrintItem::RcPath(path) => text.push_str(&get_items_as_text(path.clone(), indent_text.clone())),
                 }
             }
 
@@ -153,51 +144,36 @@ impl PrintItems {
             }
         }
     }
-}
 
-impl Clone for PrintItems {
-    fn clone(&self) -> PrintItems {
-        // todo: need to improve this to clone properly...
-        let mut items = PrintItems::new();
-        let mut next = self.first_node.clone();
-        while let Some(current) = next {
-            items.push_node(PrintNode {
-                item: current.borrow().item.clone(),
-                next: None,
-            });
-            next = current.borrow().next.clone();
-        }
-
-        items
-    }
-}
-
-impl IntoIterator for PrintItems {
-    type Item = PrintItem;
-    type IntoIter = PrintItemsIntoIterator;
-
-    fn into_iter(self) -> Self::IntoIter {
-        PrintItemsIntoIterator {
-            node: self.first_node,
+    pub fn iter(&self) -> PrintItemsIterator {
+        PrintItemsIterator {
+            node: self.first_node.clone(),
         }
     }
 }
 
-pub struct PrintItemsIntoIterator {
-    node: Option<Rc<RefCell<PrintNode>>>,
+pub struct PrintItemsIterator {
+    node: Option<PrintItemPath>,
 }
 
-impl Iterator for PrintItemsIntoIterator {
+impl PrintItemsIterator {
+    pub fn new(path: PrintItemPath) -> PrintItemsIterator {
+        PrintItemsIterator {
+            node: Some(path),
+        }
+    }
+}
+
+impl Iterator for PrintItemsIterator {
     type Item = PrintItem;
 
     fn next(&mut self) -> Option<PrintItem> {
-        let node = mem::replace(&mut self.node, None);
+        let node = self.node.take();
+
         match node {
             Some(node) => {
-                // replace with a dummy value (todo: something better?)
-                let node = node.replace(PrintNode::new(PrintItem::Signal(Signal::NewLine)));
-                self.node = node.next;
-                Some(node.item)
+                self.node = node.borrow().next.clone();
+                Some(node.borrow().item.clone())
             },
             None => None
         }
@@ -236,9 +212,37 @@ impl Into<PrintItems> for Signal {
     }
 }
 
+impl Into<PrintItems> for Option<PrintItemPath> {
+    fn into(self) -> PrintItems {
+        let mut items = PrintItems::new();
+        if let Some(path) = self {
+            items.push_path(path);
+        }
+        items
+    }
+}
+
 pub struct PrintNode<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    pub(super) next: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>,
+    pub(super) next: Option<PrintItemPath<TString, TInfo, TCondition>>,
     pub(super) item: PrintItem<TString, TInfo, TCondition>,
+}
+
+impl<TString, TInfo, TCondition> Drop for PrintNode<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+    fn drop(&mut self) {
+        let mut next = mem::replace(&mut self.next, None);
+
+        loop {
+            next = match next {
+                Some(l) => {
+                    match Rc::try_unwrap(l) {
+                        Ok(mut l) => mem::replace(&mut l.into_inner().next, None),
+                        Err(_) => break,
+                    }
+                },
+                None => break
+            }
+        }
+    }
 }
 
 impl<TString, TInfo, TCondition> PrintNode<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
@@ -249,7 +253,7 @@ impl<TString, TInfo, TCondition> PrintNode<TString, TInfo, TCondition> where TSt
         }
     }
 
-    fn set_next(&mut self, new_next: Option<Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>>) {
+    fn set_next(&mut self, new_next: Option<PrintItemPath<TString, TInfo, TCondition>>) {
         let past_next = mem::replace(&mut self.next, new_next.clone());
 
         if let Some(past_next) = past_next {
@@ -274,13 +278,16 @@ impl<TString, TInfo, TCondition> RcPrintNodeGetLast<TString, TInfo, TCondition> 
     }
 }
 
+pub type PrintItemPath<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> = Rc<RefCell<PrintNode<TString, TInfo, TCondition>>>;
+
 /// The different items the printer could encounter.
 #[derive(Clone)]
 pub enum PrintItem<TString = String, TInfo = Info, TCondition = Condition<TString, TInfo>> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
     String(Rc<TString>),
-    Condition(TCondition), // no Rc because conditions shouldn't be shared since paths must be unique
+    Condition(Rc<TCondition>),
     Info(Rc<TInfo>),
     Signal(Signal),
+    RcPath(PrintItemPath<TString, TInfo, TCondition>),
 }
 
 #[derive(Clone, PartialEq, Copy, Debug)]
@@ -335,12 +342,6 @@ impl InfoRef for Info {
     }
 }
 
-impl<TString, TCondition> Into<PrintItem<TString, Info, TCondition>> for Info where TString : StringRef, TCondition : ConditionRef<TString, Info, TCondition> {
-    fn into(self) -> PrintItem<TString, Info, TCondition> {
-        PrintItem::Info(Rc::new(self))
-    }
-}
-
 static INFO_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 impl Info {
@@ -364,45 +365,20 @@ pub struct Condition<TString = String, TInfo = Info> where TString : StringRef, 
     /// The condition to resolve.
     pub condition: Rc<Box<ConditionResolver<TString, TInfo, Condition<TString, TInfo>>>>,
     /// The items to print when the condition is true.
-    pub true_path: Option<Rc<RefCell<ConditionPath<TString, TInfo, Condition<TString, TInfo>>>>>,
+    pub true_path: Option<PrintItemPath<TString, TInfo, Condition<TString, TInfo>>>,
     /// The items to print when the condition is false or undefined (not yet resolved).
-    pub false_path: Option<Rc<RefCell<ConditionPath<TString, TInfo, Condition<TString, TInfo>>>>>,
+    pub false_path: Option<PrintItemPath<TString, TInfo, Condition<TString, TInfo>>>,
 }
 
-impl Condition {
-    /// Gets the true path as a collection of PrintItems.
-    pub fn get_true_items(&self) -> PrintItems {
-        get_items_from_condition_path(&self.true_path)
-    }
-
-    /// Gets the false path as a collection of PrintItems.
-    pub fn get_false_items(&self) -> PrintItems {
-        get_items_from_condition_path(&self.false_path)
-    }
-}
-
-fn get_items_from_condition_path(condition_path: &Option<Rc<RefCell<ConditionPath<String, Info, Condition>>>>) -> PrintItems {
-    let mut items = PrintItems::new();
-
-    if let Some(condition_path) = condition_path {
-        if let Some(first_node) = &condition_path.borrow().first_node {
-            items.push_rc_node(first_node.clone());
-        }
-    }
-
-    items
-}
-
-// need to manually implement this for some reason instead of using #[derive(Clone)]
-impl<TString, TInfo> Clone for Condition<TString, TInfo> where TString : StringRef, TInfo : InfoRef {
-    fn clone(&self) -> Condition<TString, TInfo> {
-        Condition {
+impl Clone for Condition {
+    fn clone(&self) -> Condition {
+        return Condition {
             id: self.id,
             name: self.name,
             condition: self.condition.clone(),
             true_path: self.true_path.clone(),
             false_path: self.false_path.clone(),
-        }
+        };
     }
 }
 
@@ -414,16 +390,8 @@ impl<TString, TInfo> Condition<TString, TInfo> where TString : StringRef, TInfo 
             id: CONDITION_COUNTER.fetch_add(1, Ordering::SeqCst),
             name,
             condition: Rc::new(properties.condition),
-            true_path: properties.true_path.map(|x| Rc::new(RefCell::new(ConditionPath {
-                first_node: x.first_node,
-                last_node: x.last_node,
-                has_next_set: false,
-            }))),
-            false_path: properties.false_path.map(|x| Rc::new(RefCell::new(ConditionPath {
-                first_node: x.first_node,
-                last_node: x.last_node,
-                has_next_set: false,
-            }))),
+            true_path: properties.true_path.map(|x| x.first_node).flatten(),
+            false_path: properties.false_path.map(|x| x.first_node).flatten(),
         }
     }
 }
@@ -441,18 +409,12 @@ impl<TString, TInfo> ConditionRef<TString, TInfo, Condition<TString, TInfo>> for
         (self.condition)(context)
     }
 
-    fn get_true_path(&self) -> Option<Rc<RefCell<ConditionPath<TString, TInfo, Condition<TString, TInfo>>>>> {
+    fn get_true_path(&self) -> Option<PrintItemPath<TString, TInfo, Condition<TString, TInfo>>> {
         self.true_path.clone()
     }
 
-    fn get_false_path(&self) -> Option<Rc<RefCell<ConditionPath<TString, TInfo, Condition<TString, TInfo>>>>> {
+    fn get_false_path(&self) -> Option<PrintItemPath<TString, TInfo, Condition<TString, TInfo>>> {
         self.false_path.clone()
-    }
-}
-
-impl<TString, TInfo> Into<PrintItem<TString, TInfo, Condition<TString, TInfo>>> for Condition<TString, TInfo> where TString : StringRef, TInfo : InfoRef {
-    fn into(self) -> PrintItem<TString, TInfo, Condition<TString, TInfo>> {
-        PrintItem::Condition(self)
     }
 }
 

--- a/packages/rust-core/src/print_write_items.rs
+++ b/packages/rust-core/src/print_write_items.rs
@@ -12,8 +12,8 @@ pub struct PrintWriteItemsOptions {
 }
 
 /// Prints string based writer items.
-pub fn print_write_items<'a, T>(write_items: impl Iterator<Item = WriteItem<'a, T>>, options: PrintWriteItemsOptions) -> String where T : StringRef + 'a {
-    // todo: faster string manipulation?
+pub fn print_write_items<T>(write_items: impl Iterator<Item = WriteItem<T>>, options: PrintWriteItemsOptions) -> String where T : StringRef {
+    // todo: faster string manipulation? or is this as good as it gets?
     let mut final_string = String::new();
     let indent_string = if options.use_tabs { String::from("\t") } else { " ".repeat(options.indent_width as usize) };
 

--- a/packages/rust-core/src/print_write_items.rs
+++ b/packages/rust-core/src/print_write_items.rs
@@ -23,9 +23,7 @@ pub fn print_write_items<T>(write_items: impl Iterator<Item = WriteItem<T>>, opt
             WriteItem::NewLine => final_string.push_str(&options.newline_kind),
             WriteItem::Tab => final_string.push_str("\t"),
             WriteItem::Space => final_string.push_str(" "),
-            WriteItem::String(text) => {
-                final_string.push_str(text.text.get_text());
-            },
+            WriteItem::String(text) => final_string.push_str(text.text.get_text()),
         }
     }
 

--- a/packages/rust-core/src/print_write_items.rs
+++ b/packages/rust-core/src/print_write_items.rs
@@ -19,7 +19,7 @@ pub fn print_write_items<T>(write_items: impl Iterator<Item = WriteItem<T>>, opt
 
     for item in write_items.into_iter() {
         match item {
-            WriteItem::Indent => final_string.push_str(&indent_string),
+            WriteItem::Indent(times) => final_string.push_str(&indent_string.repeat(times as usize)),
             WriteItem::NewLine => final_string.push_str(&options.newline_kind),
             WriteItem::Tab => final_string.push_str("\t"),
             WriteItem::Space => final_string.push_str(" "),

--- a/packages/rust-core/src/print_write_items.rs
+++ b/packages/rust-core/src/print_write_items.rs
@@ -24,7 +24,7 @@ pub fn print_write_items<T>(write_items: impl Iterator<Item = WriteItem<T>>, opt
             WriteItem::Tab => final_string.push_str("\t"),
             WriteItem::Space => final_string.push_str(" "),
             WriteItem::String(text) => {
-                final_string.push_str(&text.get_text_clone());
+                final_string.push_str(text.text.get_text());
             },
         }
     }

--- a/packages/rust-core/src/print_write_items.rs
+++ b/packages/rust-core/src/print_write_items.rs
@@ -1,4 +1,4 @@
-use super::StringRef;
+use super::StringTrait;
 use super::WriteItem;
 
 pub struct PrintWriteItemsOptions {
@@ -12,7 +12,7 @@ pub struct PrintWriteItemsOptions {
 }
 
 /// Prints string based writer items.
-pub fn print_write_items<T>(write_items: impl Iterator<Item = WriteItem<T>>, options: PrintWriteItemsOptions) -> String where T : StringRef {
+pub fn print_write_items<T>(write_items: impl Iterator<Item = WriteItem<T>>, options: PrintWriteItemsOptions) -> String where T : StringTrait {
     // todo: faster string manipulation? or is this as good as it gets?
     let mut final_string = String::new();
     let indent_string = if options.use_tabs { String::from("\t") } else { " ".repeat(options.indent_width as usize) };

--- a/packages/rust-core/src/printer.rs
+++ b/packages/rust-core/src/printer.rs
@@ -1,5 +1,4 @@
 use super::WriteItem;
-use super::collections::*;
 use super::print_items::*;
 use super::writer::*;
 use super::get_write_items::{GetWriteItemsOptions};
@@ -9,8 +8,6 @@ use std::rc::Rc;
 
 #[derive(Clone)]
 struct SavePoint<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
-    // Unique id
-    pub id: u32,
     /// Name for debugging purposes.
     pub name: &'static str,
     pub new_line_group_depth: u16,
@@ -40,7 +37,6 @@ pub struct Printer<TString, TInfo, TCondition> where TString : StringRef, TInfo 
     possible_new_line_save_point: Option<Rc<SavePoint<TString, TInfo, TCondition>>>,
     new_line_group_depth: u16,
     current_node: Option<PrintItemPath<TString, TInfo, TCondition>>,
-    save_point_increment: u32, // todo: remove
     writer: Writer<TString>,
     resolved_conditions: HashMap<usize, Option<bool>>,
     resolved_infos: HashMap<usize, WriterInfo>,
@@ -58,7 +54,6 @@ impl<'a, TString, TInfo, TCondition> Printer<TString, TInfo, TCondition> where T
             possible_new_line_save_point: None,
             new_line_group_depth: 0,
             current_node: start_node,
-            save_point_increment: 0,
             writer: Writer::new(WriterOptions {
                 indent_width: options.indent_width,
             }),
@@ -151,9 +146,7 @@ impl<'a, TString, TInfo, TCondition> Printer<TString, TInfo, TCondition> where T
     }
 
     fn create_save_point(&mut self, name: &'static str, next_node: Option<PrintItemPath<TString, TInfo, TCondition>>) -> Rc<SavePoint<TString, TInfo, TCondition>> {
-        self.save_point_increment += 1;
         Rc::new(SavePoint {
-            id: self.save_point_increment,
             name,
             possible_new_line_save_point: self.possible_new_line_save_point.clone(),
             new_line_group_depth: self.new_line_group_depth,

--- a/packages/rust-core/src/printer.rs
+++ b/packages/rust-core/src/printer.rs
@@ -72,7 +72,7 @@ impl<'a, TString, TInfo, TCondition> Printer<TString, TInfo, TCondition> where T
     /// Turns the print items into a collection of writer items according to the options.
     pub fn print(mut self) -> impl Iterator<Item = WriteItem<TString>> {
         while let Some(current_node) = &self.current_node {
-            let current_node = unsafe { &*current_node.get() }; // ok because values won't be mutated while printing
+            let current_node = unsafe { &*current_node.get_node() }; // ok because values won't be mutated while printing
             self.handle_print_node(current_node);
 
             if self.skip_moving_next {

--- a/packages/rust-core/src/printer.rs
+++ b/packages/rust-core/src/printer.rs
@@ -7,7 +7,7 @@ use std::mem::{self, MaybeUninit};
 use std::rc::Rc;
 use std::cell::UnsafeCell;
 
-struct SavePoint<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+struct SavePoint<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     /// Name for debugging purposes.
     pub name: &'static str,
     pub new_line_group_depth: u16,
@@ -19,12 +19,12 @@ struct SavePoint<TString, TInfo, TCondition> where TString : StringRef, TInfo : 
     pub next_node_stack: Vec<Option<PrintItemPath<TString, TInfo, TCondition>>>,
 }
 
-struct PrintItemContainer<'a, TString, TInfo, TCondition> where TString : StringRef, TInfo: InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+struct PrintItemContainer<'a, TString, TInfo, TCondition> where TString : StringTrait, TInfo: InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     items: &'a Vec<PrintItem<TString, TInfo, TCondition>>,
     index: i32,
 }
 
-impl<'a, TString, TInfo, TCondition> Clone for PrintItemContainer<'a, TString, TInfo, TCondition> where TString : StringRef, TInfo: InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+impl<'a, TString, TInfo, TCondition> Clone for PrintItemContainer<'a, TString, TInfo, TCondition> where TString : StringTrait, TInfo: InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     fn clone(&self) -> PrintItemContainer<'a, TString, TInfo, TCondition> {
         PrintItemContainer {
             items: self.items,
@@ -33,7 +33,7 @@ impl<'a, TString, TInfo, TCondition> Clone for PrintItemContainer<'a, TString, T
     }
 }
 
-pub struct Printer<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+pub struct Printer<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     possible_new_line_save_point: Option<Rc<SavePoint<TString, TInfo, TCondition>>>,
     new_line_group_depth: u16,
     current_node: Option<PrintItemPath<TString, TInfo, TCondition>>,
@@ -48,7 +48,7 @@ pub struct Printer<TString, TInfo, TCondition> where TString : StringRef, TInfo 
     is_testing: bool, // todo: compiler directives
 }
 
-impl<'a, TString, TInfo, TCondition> Printer<TString, TInfo, TCondition> where TString : StringRef, TInfo : InfoRef, TCondition : ConditionRef<TString, TInfo, TCondition> {
+impl<'a, TString, TInfo, TCondition> Printer<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     pub fn new(start_node: Option<PrintItemPath<TString, TInfo, TCondition>>, options: GetWriteItemsOptions) -> Printer<TString, TInfo, TCondition> {
         Printer {
             possible_new_line_save_point: None,

--- a/packages/rust-core/src/printer.rs
+++ b/packages/rust-core/src/printer.rs
@@ -6,7 +6,6 @@ use super::get_write_items::{GetWriteItemsOptions};
 use std::collections::HashMap;
 use std::mem::{self, MaybeUninit};
 use std::rc::Rc;
-use std::cell::UnsafeCell;
 
 struct SavePoint<TString, TInfo, TCondition> where TString : StringTrait, TInfo : InfoTrait, TCondition : ConditionTrait<TString, TInfo, TCondition> {
     /// Name for debugging purposes.
@@ -304,8 +303,7 @@ impl<'a, TString, TInfo, TCondition> Printer<TString, TInfo, TCondition> where T
             panic!("Don't call this method unless self.is_testing is true.");
         }
 
-        // This is possibly very slow (ex. could be a JS utf16 string that gets encoded to a rust utf8 string)
-        let text_as_string = text.get_text_clone();
+        let text_as_string = text.get_text();
         if text_as_string.contains("\t") {
             panic!("Found a tab in the string. Before sending the string to the printer it needs to be broken up and the tab sent as a PrintItem::Tab. {0}", text_as_string);
         }

--- a/packages/rust-core/src/write_items.rs
+++ b/packages/rust-core/src/write_items.rs
@@ -1,8 +1,9 @@
 use std::rc::Rc;
+use super::StringContainer;
 use super::StringRef;
 
 pub enum WriteItem<T = String> where T : StringRef {
-    String(Rc<T>),
+    String(Rc<StringContainer<T>>),
     Indent,
     NewLine,
     Tab,

--- a/packages/rust-core/src/write_items.rs
+++ b/packages/rust-core/src/write_items.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
 use super::StringContainer;
-use super::StringRef;
+use super::StringTrait;
 
-pub enum WriteItem<T = String> where T : StringRef {
+pub enum WriteItem<T = String> where T : StringTrait {
     String(Rc<StringContainer<T>>),
     Indent(u8),
     NewLine,
@@ -11,7 +11,7 @@ pub enum WriteItem<T = String> where T : StringRef {
 }
 
 // for some reason #[derive(Clone)] was not working, so manually implement this...
-impl<TString> Clone for WriteItem<TString> where TString : StringRef {
+impl<TString> Clone for WriteItem<TString> where TString : StringTrait {
     fn clone(&self) -> WriteItem<TString> {
         match self {
             WriteItem::Indent(times) => WriteItem::Indent(*times),

--- a/packages/rust-core/src/write_items.rs
+++ b/packages/rust-core/src/write_items.rs
@@ -1,7 +1,8 @@
+use std::rc::Rc;
 use super::StringRef;
 
-pub enum WriteItem<'a, T = String> where T : StringRef {
-    String(&'a T),
+pub enum WriteItem<T = String> where T : StringRef {
+    String(Rc<T>),
     Indent,
     NewLine,
     Tab,
@@ -9,14 +10,14 @@ pub enum WriteItem<'a, T = String> where T : StringRef {
 }
 
 // for some reason #[derive(Clone)] was not working, so manually implement this...
-impl<'a, TString> Clone for WriteItem<'a, TString> where TString : StringRef {
-    fn clone(&self) -> WriteItem<'a, TString> {
+impl<TString> Clone for WriteItem<TString> where TString : StringRef {
+    fn clone(&self) -> WriteItem<TString> {
         match self {
             WriteItem::Indent => WriteItem::Indent,
             WriteItem::NewLine => WriteItem::NewLine,
             WriteItem::Tab => WriteItem::Tab,
             WriteItem::Space => WriteItem::Space,
-            WriteItem::String(text) => WriteItem::String(text),
+            WriteItem::String(text) => WriteItem::String(text.clone()),
         }
     }
 }

--- a/packages/rust-core/src/write_items.rs
+++ b/packages/rust-core/src/write_items.rs
@@ -4,7 +4,7 @@ use super::StringRef;
 
 pub enum WriteItem<T = String> where T : StringRef {
     String(Rc<StringContainer<T>>),
-    Indent,
+    Indent(u8),
     NewLine,
     Tab,
     Space,
@@ -14,7 +14,7 @@ pub enum WriteItem<T = String> where T : StringRef {
 impl<TString> Clone for WriteItem<TString> where TString : StringRef {
     fn clone(&self) -> WriteItem<TString> {
         match self {
-            WriteItem::Indent => WriteItem::Indent,
+            WriteItem::Indent(times) => WriteItem::Indent(*times),
             WriteItem::NewLine => WriteItem::NewLine,
             WriteItem::Tab => WriteItem::Tab,
             WriteItem::Space => WriteItem::Space,

--- a/packages/rust-core/src/write_items.rs
+++ b/packages/rust-core/src/write_items.rs
@@ -1,8 +1,7 @@
-use std::rc::Rc;
 use super::StringRef;
 
-pub enum WriteItem<T = String> where T : StringRef {
-    String(Rc<T>),
+pub enum WriteItem<'a, T = String> where T : StringRef {
+    String(&'a T),
     Indent,
     NewLine,
     Tab,
@@ -10,14 +9,14 @@ pub enum WriteItem<T = String> where T : StringRef {
 }
 
 // for some reason #[derive(Clone)] was not working, so manually implement this...
-impl<TString> Clone for WriteItem<TString> where TString : StringRef {
-    fn clone(&self) -> WriteItem<TString> {
+impl<'a, TString> Clone for WriteItem<'a, TString> where TString : StringRef {
+    fn clone(&self) -> WriteItem<'a, TString> {
         match self {
             WriteItem::Indent => WriteItem::Indent,
             WriteItem::NewLine => WriteItem::NewLine,
             WriteItem::Tab => WriteItem::Tab,
             WriteItem::Space => WriteItem::Space,
-            WriteItem::String(text) => WriteItem::String(text.clone()),
+            WriteItem::String(text) => WriteItem::String(text),
         }
     }
 }

--- a/packages/rust-core/src/writer.rs
+++ b/packages/rust-core/src/writer.rs
@@ -179,7 +179,7 @@ impl<T> Writer<T> where T : StringTrait {
     pub fn get_items(self) -> impl Iterator<Item = WriteItem<T>> {
         match self.state.items {
             Some(items) => Rc::try_unwrap(items).ok().expect("Expected to unwrap from RC at this point.").into_iter().collect::<Vec<WriteItem<T>>>().into_iter().rev(),
-            None => GraphNodeIterator::empty().collect::<Vec<WriteItem<T>>>().into_iter().rev(), // todo: look to see if there's a way to make this faster
+            None => GraphNodeIterator::empty().collect::<Vec<WriteItem<T>>>().into_iter().rev(),
         }
     }
 }

--- a/packages/rust-core/src/writer.rs
+++ b/packages/rust-core/src/writer.rs
@@ -3,6 +3,8 @@ use super::WriteItem;
 use super::collections::{GraphNode, GraphNodeIterator};
 use std::rc::Rc;
 
+// TOOODOOO: Could the next node be saved instead of the previous?? Would avoid the reverse at the end.
+
 pub struct WriterState<T> where T : StringRef {
     current_line_column: u32,
     current_line_number: u32,

--- a/packages/rust-core/src/writer.rs
+++ b/packages/rust-core/src/writer.rs
@@ -55,7 +55,7 @@ impl<T> Writer<T> where T : StringRef {
         }
     }
 
-    pub fn get_state(&mut self) -> WriterState<T> {
+    pub fn get_state(&self) -> WriterState<T> {
         self.state.clone()
     }
 

--- a/packages/rust-core/src/writer.rs
+++ b/packages/rust-core/src/writer.rs
@@ -9,8 +9,8 @@ use std::rc::Rc;
 pub struct WriterState<T> where T : StringRef {
     current_line_column: u32,
     current_line_number: u32,
-    last_line_indent_level: u16,
-    indent_level: u16,
+    last_line_indent_level: u8,
+    indent_level: u8,
     expect_newline_next: bool,
     ignore_indent_count: u8,
     items: Option<Rc<GraphNode<WriteItem<T>>>>,
@@ -75,7 +75,7 @@ impl<T> Writer<T> where T : StringRef {
         self.set_indent_level(self.state.indent_level - 1);
     }
 
-    fn set_indent_level(&mut self, new_level: u16) {
+    fn set_indent_level(&mut self, new_level: u8) {
         self.state.indent_level = new_level;
 
         // If it's on the first column, update the indent level
@@ -97,11 +97,11 @@ impl<T> Writer<T> where T : StringRef {
         self.state.expect_newline_next = true;
     }
 
-    pub fn get_line_start_indent_level(&self) -> u16 {
+    pub fn get_line_start_indent_level(&self) -> u8 {
         self.state.last_line_indent_level
     }
 
-    pub fn get_indentation_level(&self) -> u16 {
+    pub fn get_indentation_level(&self) -> u8 {
         self.state.indent_level
     }
 
@@ -132,7 +132,7 @@ impl<T> Writer<T> where T : StringRef {
     pub fn single_indent(&mut self) {
         self.handle_first_column();
         self.state.current_line_column += self.indent_width as u32;
-        self.push_item(WriteItem::Indent);
+        self.push_item(WriteItem::Indent(1));
     }
 
     pub fn tab(&mut self) {
@@ -163,8 +163,8 @@ impl<T> Writer<T> where T : StringRef {
             // update the indent level again since on the first column
             self.state.last_line_indent_level = self.state.indent_level;
 
-            for _ in 0..self.state.indent_level {
-                self.push_item(WriteItem::Indent);
+            if self.state.indent_level > 0 {
+                self.push_item(WriteItem::Indent(self.state.indent_level));
             }
 
             self.state.current_line_column += self.state.indent_level as u32 * self.indent_width as u32;

--- a/packages/rust-core/src/writer.rs
+++ b/packages/rust-core/src/writer.rs
@@ -1,12 +1,12 @@
 use super::StringContainer;
-use super::StringRef;
+use super::StringTrait;
 use super::WriteItem;
 use super::collections::{GraphNode, GraphNodeIterator};
 use std::rc::Rc;
 
 // TOOODOOO: Could the next node be saved instead of the previous?? Would avoid the reverse at the end.
 
-pub struct WriterState<T> where T : StringRef {
+pub struct WriterState<T> where T : StringTrait {
     current_line_column: u32,
     current_line_number: u32,
     last_line_indent_level: u8,
@@ -16,7 +16,7 @@ pub struct WriterState<T> where T : StringRef {
     items: Option<Rc<GraphNode<WriteItem<T>>>>,
 }
 
-impl<T> Clone for WriterState<T> where T : StringRef {
+impl<T> Clone for WriterState<T> where T : StringTrait {
     fn clone(&self) -> WriterState<T> {
         WriterState {
             current_line_column: self.current_line_column,
@@ -34,12 +34,12 @@ pub struct WriterOptions {
     pub indent_width: u8,
 }
 
-pub struct Writer<T> where T : StringRef {
+pub struct Writer<T> where T : StringTrait {
     state: WriterState<T>,
     indent_width: u8,
 }
 
-impl<T> Writer<T> where T : StringRef {
+impl<T> Writer<T> where T : StringTrait {
     pub fn new(options: WriterOptions) -> Writer<T> {
         Writer {
             indent_width: options.indent_width,

--- a/packages/rust-core/src/writer.rs
+++ b/packages/rust-core/src/writer.rs
@@ -3,18 +3,18 @@ use super::WriteItem;
 use super::collections::{GraphNode, GraphNodeIterator};
 use std::rc::Rc;
 
-pub struct WriterState<T> where T : StringRef {
+pub struct WriterState<'a, T> where T : StringRef {
     current_line_column: u32,
     current_line_number: u32,
     last_line_indent_level: u16,
     indent_level: u16,
     expect_newline_next: bool,
     ignore_indent_count: u8,
-    items: Option<Rc<GraphNode<WriteItem<T>>>>,
+    items: Option<Rc<GraphNode<WriteItem<'a, T>>>>,
 }
 
-impl<T> Clone for WriterState<T> where T : StringRef {
-    fn clone(&self) -> WriterState<T> {
+impl<'a, T> Clone for WriterState<'a, T> where T : StringRef {
+    fn clone(&self) -> WriterState<'a, T> {
         WriterState {
             current_line_column: self.current_line_column,
             current_line_number: self.current_line_number,
@@ -31,13 +31,13 @@ pub struct WriterOptions {
     pub indent_width: u8,
 }
 
-pub struct Writer<T> where T : StringRef {
-    state: WriterState<T>,
+pub struct Writer<'a, T> where T : StringRef {
+    state: WriterState<'a, T>,
     indent_width: u8,
 }
 
-impl<T> Writer<T> where T : StringRef {
-    pub fn new(options: WriterOptions) -> Writer<T> {
+impl<'a, T> Writer<'a, T> where T : StringRef {
+    pub fn new(options: WriterOptions) -> Writer<'a, T> {
         Writer {
             indent_width: options.indent_width,
             state: WriterState {
@@ -52,11 +52,11 @@ impl<T> Writer<T> where T : StringRef {
         }
     }
 
-    pub fn get_state(&mut self) -> WriterState<T> {
+    pub fn get_state(&mut self) -> WriterState<'a, T> {
         self.state.clone()
     }
 
-    pub fn set_state(&mut self, state: WriterState<T>) {
+    pub fn set_state(&mut self, state: WriterState<'a, T>) {
         self.state = state;
     }
 
@@ -144,10 +144,10 @@ impl<T> Writer<T> where T : StringRef {
         self.push_item(WriteItem::Space);
     }
 
-    pub fn write(&mut self, text: &Rc<T>) {
+    pub fn write(&mut self, text: &'a T) {
         self.handle_first_column();
         self.state.current_line_column += text.get_length() as u32;
-        self.push_item(WriteItem::String(text.clone()));
+        self.push_item(WriteItem::String(text));
     }
 
     fn handle_first_column(&mut self) {
@@ -168,12 +168,12 @@ impl<T> Writer<T> where T : StringRef {
         }
     }
 
-    fn push_item(&mut self, item: WriteItem<T>) {
+    fn push_item(&mut self, item: WriteItem<'a, T>) {
         let previous = std::mem::replace(&mut self.state.items, None);
         self.state.items = Some(Rc::new(GraphNode::new(item, previous)));
     }
 
-    pub fn get_items(self) -> impl Iterator<Item = WriteItem<T>> {
+    pub fn get_items(self) -> impl Iterator<Item = WriteItem<'a, T>> {
         match self.state.items {
             Some(items) => Rc::try_unwrap(items).ok().expect("Expected to unwrap from RC at this point.").into_iter().collect::<Vec<WriteItem<T>>>().into_iter().rev(),
             None => GraphNodeIterator::empty().collect::<Vec<WriteItem<T>>>().into_iter().rev(),

--- a/packages/rust-core/src/writer.rs
+++ b/packages/rust-core/src/writer.rs
@@ -4,8 +4,6 @@ use super::WriteItem;
 use super::collections::{GraphNode, GraphNodeIterator};
 use std::rc::Rc;
 
-// TOOODOOO: Could the next node be saved instead of the previous?? Would avoid the reverse at the end.
-
 pub struct WriterState<T> where T : StringTrait {
     current_line_column: u32,
     current_line_number: u32,

--- a/packages/rust-core/src/writer.rs
+++ b/packages/rust-core/src/writer.rs
@@ -1,3 +1,4 @@
+use super::StringContainer;
 use super::StringRef;
 use super::WriteItem;
 use super::collections::{GraphNode, GraphNodeIterator};
@@ -146,9 +147,9 @@ impl<T> Writer<T> where T : StringRef {
         self.push_item(WriteItem::Space);
     }
 
-    pub fn write(&mut self, text: Rc<T>) {
+    pub fn write(&mut self, text: Rc<StringContainer<T>>) {
         self.handle_first_column();
-        self.state.current_line_column += text.get_length() as u32;
+        self.state.current_line_column += text.char_count;
         self.push_item(WriteItem::String(text));
     }
 

--- a/packages/rust-core/src/writer_tests.rs
+++ b/packages/rust-core/src/writer_tests.rs
@@ -51,7 +51,7 @@ fn markexpectnewline_writesnewline() {
     assert_writer_equal(writer, "1\n2");
 }
 
-fn assert_writer_equal<'a>(writer: Writer<'a, String>, text: &str) {
+fn assert_writer_equal(writer: Writer<String>, text: &str) {
     let result = print_write_items(writer.get_items(), PrintWriteItemsOptions {
         indent_width: 2,
         use_tabs: false,
@@ -60,11 +60,10 @@ fn assert_writer_equal<'a>(writer: Writer<'a, String>, text: &str) {
     assert_eq!(result, String::from(text));
 }
 
-fn write_text<'a>(writer: &mut Writer<'a, String>, text: &'static str) {
-    // todo...
-    // writer.write(&String::from(text));
+fn write_text(writer: &mut Writer<String>, text: &'static str) {
+    writer.write(Rc::new(String::from(text)));
 }
 
-fn create_writer<'a>() -> Writer<'a, String> {
+fn create_writer() -> Writer<String> {
     Writer::new(WriterOptions { indent_width: 2 })
 }

--- a/packages/rust-core/src/writer_tests.rs
+++ b/packages/rust-core/src/writer_tests.rs
@@ -51,7 +51,7 @@ fn markexpectnewline_writesnewline() {
     assert_writer_equal(writer, "1\n2");
 }
 
-fn assert_writer_equal(writer: Writer<String>, text: &str) {
+fn assert_writer_equal<'a>(writer: Writer<'a, String>, text: &str) {
     let result = print_write_items(writer.get_items(), PrintWriteItemsOptions {
         indent_width: 2,
         use_tabs: false,
@@ -60,10 +60,11 @@ fn assert_writer_equal(writer: Writer<String>, text: &str) {
     assert_eq!(result, String::from(text));
 }
 
-fn write_text(writer: &mut Writer<String>, text: &'static str) {
-    writer.write(&Rc::new(String::from(text)));
+fn write_text<'a>(writer: &mut Writer<'a, String>, text: &'static str) {
+    // todo...
+    // writer.write(&String::from(text));
 }
 
-fn create_writer() -> Writer<String> {
+fn create_writer<'a>() -> Writer<'a, String> {
     Writer::new(WriterOptions { indent_width: 2 })
 }

--- a/packages/rust-core/src/writer_tests.rs
+++ b/packages/rust-core/src/writer_tests.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 use super::writer::*;
 use super::print_write_items;
+use super::StringContainer;
 use super::PrintWriteItemsOptions;
 
 // todo: some basic unit tests just to make sure I'm not way off
@@ -61,7 +62,7 @@ fn assert_writer_equal(writer: Writer<String>, text: &str) {
 }
 
 fn write_text(writer: &mut Writer<String>, text: &'static str) {
-    writer.write(Rc::new(String::from(text)));
+    writer.write(Rc::new(StringContainer::new(String::from(text))));
 }
 
 fn create_writer() -> Writer<String> {

--- a/packages/rust-core/tests/sample_example_test.rs
+++ b/packages/rust-core/tests/sample_example_test.rs
@@ -89,8 +89,8 @@ fn it_formats_as_multi_line_when_items_exceed_print_width() {
 }
 
 fn do_test(expr: &ArrayLiteralExpression, expected_text: &str) {
-    let print_items = parse_node(Node::ArrayLiteralExpression(expr));
-    let write_items = dprint_core::get_write_items(vec![print_items], GetWriteItemsOptions {
+    let print_items = vec![parse_node(Node::ArrayLiteralExpression(expr))];
+    let write_items = dprint_core::get_write_items(&print_items, GetWriteItemsOptions {
         indent_width: 2,
         max_width: 40,
         is_testing: true,
@@ -134,11 +134,11 @@ fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItem {
         PrintItem::NewLine
     ));
 
-    let parsed_elements = parse_elements(&expr.elements, &is_multiple_lines);
+    let parsed_elements = parse_elements(&expr.elements, &is_multiple_lines).into_rc();
     items.push(Condition::new("indentIfMultipleLines", ConditionProperties {
         condition: Box::new(is_multiple_lines.clone()),
-        true_path: Some(parser_helpers::with_indent(parsed_elements.clone())),
-        false_path: Some(parsed_elements),
+        true_path: Some(parser_helpers::with_indent(parsed_elements.clone().into())),
+        false_path: Some(parsed_elements.into()),
     }).into());
 
     items.push(parser_helpers::if_true(

--- a/packages/rust-core/tests/sample_example_test.rs
+++ b/packages/rust-core/tests/sample_example_test.rs
@@ -134,11 +134,11 @@ fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItems {
         Signal::NewLine.into()
     ));
 
-    let parsed_elements = parse_elements(&expr.elements, &is_multiple_lines);
+    let parsed_elements = parse_elements(&expr.elements, &is_multiple_lines).into_rc_path();
     items.push_condition(Condition::new("indentIfMultipleLines", ConditionProperties {
         condition: Box::new(is_multiple_lines.clone()),
-        true_path: Some(parser_helpers::with_indent(parsed_elements.clone())),
-        false_path: Some(parsed_elements),
+        true_path: Some(parser_helpers::with_indent(parsed_elements.clone().into())),
+        false_path: Some(parsed_elements.into()),
     }).into());
 
     items.extend(parser_helpers::if_true(

--- a/packages/rust-core/tests/sample_example_test.rs
+++ b/packages/rust-core/tests/sample_example_test.rs
@@ -121,8 +121,8 @@ fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItems {
     let is_multiple_lines = create_is_multiple_lines_resolver(
         expr.position.clone(),
         expr.elements.iter().map(|e| e.position.clone()).collect(),
-        start_info.clone(),
-        end_info.clone()
+        start_info,
+        end_info
     );
 
     items.push_info(start_info);
@@ -178,7 +178,7 @@ fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItems {
 }
 
 fn parse_array_element(element: &ArrayElement) -> PrintItems {
-    element.text.clone().into()
+    (&element.text).into()
 }
 
 // helper functions

--- a/packages/rust-core/tests/sample_example_test.rs
+++ b/packages/rust-core/tests/sample_example_test.rs
@@ -89,7 +89,7 @@ fn it_formats_as_multi_line_when_items_exceed_print_width() {
 }
 
 fn do_test(expr: &ArrayLiteralExpression, expected_text: &str) {
-    let print_items = vec![parse_node(Node::ArrayLiteralExpression(expr))];
+    let print_items = parse_node(Node::ArrayLiteralExpression(expr));
     let write_items = dprint_core::get_write_items(&print_items, GetWriteItemsOptions {
         indent_width: 2,
         max_width: 40,
@@ -105,7 +105,7 @@ fn do_test(expr: &ArrayLiteralExpression, expected_text: &str) {
 
 // node parsing functions
 
-fn parse_node(node: Node) -> PrintItem {
+fn parse_node(node: Node) -> PrintItems {
     // in a real implementation this function would deal with surrounding comments
 
     match node {
@@ -114,8 +114,8 @@ fn parse_node(node: Node) -> PrintItem {
     }
 }
 
-fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItem {
-    let mut items: Vec<PrintItem> = Vec::new();
+fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_info = Info::new("start");
     let end_info = Info::new("end");
     let is_multiple_lines = create_is_multiple_lines_resolver(
@@ -125,59 +125,59 @@ fn parse_array_literal_expression(expr: &ArrayLiteralExpression) -> PrintItem {
         end_info.clone()
     );
 
-    items.push(start_info.into());
+    items.push_info(start_info);
 
-    items.push("[".into());
-    items.push(parser_helpers::if_true(
+    items.push_str("[");
+    items.extend(parser_helpers::if_true(
         "arrayStartNewLine",
         is_multiple_lines.clone(),
-        PrintItem::NewLine
+        Signal::NewLine.into()
     ));
 
-    let parsed_elements = parse_elements(&expr.elements, &is_multiple_lines).into_rc();
-    items.push(Condition::new("indentIfMultipleLines", ConditionProperties {
+    let parsed_elements = parse_elements(&expr.elements, &is_multiple_lines);
+    items.push_condition(Condition::new("indentIfMultipleLines", ConditionProperties {
         condition: Box::new(is_multiple_lines.clone()),
-        true_path: Some(parser_helpers::with_indent(parsed_elements.clone().into())),
-        false_path: Some(parsed_elements.into()),
+        true_path: Some(parser_helpers::with_indent(parsed_elements.clone())),
+        false_path: Some(parsed_elements),
     }).into());
 
-    items.push(parser_helpers::if_true(
+    items.extend(parser_helpers::if_true(
         "arrayEndNewLine",
         is_multiple_lines,
-        PrintItem::NewLine
+        Signal::NewLine.into()
     ));
-    items.push("]".into());
+    items.push_str("]");
 
-    items.push(end_info.into());
+    items.push_info(end_info);
 
-    return items.into();
+    return items;
 
     fn parse_elements(
         elements: &Vec<ArrayElement>,
         is_multiple_lines: &(impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static)
-    ) -> PrintItem {
-        let mut items = Vec::new();
+    ) -> PrintItems {
+        let mut items = PrintItems::new();
         let elements_len = elements.len();
 
         for (i, elem) in elements.iter().enumerate() {
-            items.push(parse_node(Node::ArrayElement(elem)));
+            items.extend(parse_node(Node::ArrayElement(elem)));
 
             if i < elements_len - 1 {
-                items.push(",".into());
-                items.push(parser_helpers::if_true_or(
+                items.push_str(",");
+                items.extend(parser_helpers::if_true_or(
                     "afterCommaSeparator",
                     is_multiple_lines.clone(),
-                    PrintItem::NewLine,
-                    PrintItem::SpaceOrNewLine
+                    Signal::NewLine.into(),
+                    Signal::SpaceOrNewLine.into()
                 ));
             }
         }
 
-        items.into()
+        items
     }
 }
 
-fn parse_array_element(element: &ArrayElement) -> PrintItem {
+fn parse_array_element(element: &ArrayElement) -> PrintItems {
     element.text.clone().into()
 }
 

--- a/packages/rust-dprint-plugin-typescript/src/format_text.rs
+++ b/packages/rust-dprint-plugin-typescript/src/format_text.rs
@@ -1,7 +1,6 @@
 use super::*;
 use dprint_core::*;
 use swc_common::{BytePos, comments::{Comment}};
-use std::time::Instant;
 
 pub fn format_text(file_path: &str, file_text: &str, config: &TypeScriptConfiguration) -> Result<Option<String>, String> {
     return swc_common::GLOBALS.set(&swc_common::Globals::new(), || {
@@ -10,20 +9,14 @@ pub fn format_text(file_path: &str, file_text: &str, config: &TypeScriptConfigur
             return Ok(None);
         }
 
-        let start = Instant::now();
         let print_items = parse(parsed_source_file, config.clone());
-        println!("{}ms", start.elapsed().as_millis());
-        let start = Instant::now();
 
-        let result = Some(print(print_items, PrintOptions {
+        Ok(Some(print(print_items, PrintOptions {
             indent_width: config.indent_width,
             max_width: config.line_width,
             use_tabs: config.use_tabs,
             newline_kind: get_new_line_kind(file_text, config),
-        }));
-        println!("{}ms", start.elapsed().as_millis());
-
-        Ok(result)
+        })))
     });
 
     fn get_new_line_kind(file_text: &str, config: &TypeScriptConfiguration) -> &'static str {

--- a/packages/rust-dprint-plugin-typescript/src/format_text.rs
+++ b/packages/rust-dprint-plugin-typescript/src/format_text.rs
@@ -12,8 +12,7 @@ pub fn format_text(file_path: &str, file_text: &str, config: &TypeScriptConfigur
 
         let start = Instant::now();
         let print_items = parse(parsed_source_file, config.clone());
-        //println!("{}ms", start.elapsed().as_millis());
-        //println!("Text: {}", print_items.clone().get_as_text());
+        println!("{}ms", start.elapsed().as_millis());
 
         Ok(Some(print(print_items, PrintOptions {
             indent_width: config.indent_width,

--- a/packages/rust-dprint-plugin-typescript/src/format_text.rs
+++ b/packages/rust-dprint-plugin-typescript/src/format_text.rs
@@ -13,14 +13,18 @@ pub fn format_text(file_path: &str, file_text: &str, config: &TypeScriptConfigur
         let start = Instant::now();
         let print_items = parse(parsed_source_file, config.clone());
         println!("{}ms", start.elapsed().as_millis());
+        let start = Instant::now();
 
-        Ok(Some(print(print_items, PrintOptions {
+        let result = Some(print(print_items, PrintOptions {
             indent_width: config.indent_width,
             max_width: config.line_width,
             is_testing: false, // todo: this should be true when testing
             use_tabs: config.use_tabs,
             newline_kind: get_new_line_kind(file_text, config),
-        })))
+        }));
+        println!("{}ms", start.elapsed().as_millis());
+
+        Ok(result)
     });
 
     fn get_new_line_kind(file_text: &str, config: &TypeScriptConfiguration) -> &'static str {

--- a/packages/rust-dprint-plugin-typescript/src/format_text.rs
+++ b/packages/rust-dprint-plugin-typescript/src/format_text.rs
@@ -18,7 +18,6 @@ pub fn format_text(file_path: &str, file_text: &str, config: &TypeScriptConfigur
         let result = Some(print(print_items, PrintOptions {
             indent_width: config.indent_width,
             max_width: config.line_width,
-            is_testing: false, // todo: this should be true when testing
             use_tabs: config.use_tabs,
             newline_kind: get_new_line_kind(file_text, config),
         }));

--- a/packages/rust-dprint-plugin-typescript/src/format_text.rs
+++ b/packages/rust-dprint-plugin-typescript/src/format_text.rs
@@ -12,9 +12,10 @@ pub fn format_text(file_path: &str, file_text: &str, config: &TypeScriptConfigur
 
         let start = Instant::now();
         let print_items = parse(parsed_source_file, config.clone());
-        println!("{}ms", start.elapsed().as_millis());
+        //println!("{}ms", start.elapsed().as_millis());
+        //println!("Text: {}", print_items.clone().get_as_text());
 
-        Ok(Some(print(vec![print_items], PrintOptions { // todo: remove that vec!...
+        Ok(Some(print(print_items, PrintOptions {
             indent_width: config.indent_width,
             max_width: config.line_width,
             is_testing: false, // todo: this should be true when testing

--- a/packages/rust-dprint-plugin-typescript/src/format_text.rs
+++ b/packages/rust-dprint-plugin-typescript/src/format_text.rs
@@ -1,6 +1,7 @@
 use super::*;
 use dprint_core::*;
 use swc_common::{BytePos, comments::{Comment}};
+use std::time::Instant;
 
 pub fn format_text(file_path: &str, file_text: &str, config: &TypeScriptConfiguration) -> Result<Option<String>, String> {
     return swc_common::GLOBALS.set(&swc_common::Globals::new(), || {
@@ -8,9 +9,12 @@ pub fn format_text(file_path: &str, file_text: &str, config: &TypeScriptConfigur
         if !should_format_file(&mut parsed_source_file) {
             return Ok(None);
         }
-        let print_items = parse(parsed_source_file, config.clone());
 
-        Ok(Some(print(print_items, PrintOptions {
+        let start = Instant::now();
+        let print_items = parse(parsed_source_file, config.clone());
+        println!("{}ms", start.elapsed().as_millis());
+
+        Ok(Some(print(vec![print_items], PrintOptions { // todo: remove that vec!...
             indent_width: config.indent_width,
             max_width: config.line_width,
             is_testing: false, // todo: this should be true when testing

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -11,7 +11,7 @@ use swc_ecma_parser::{token::{TokenAndSpan}};
 
 // todo: Remove putting functions on heap by using type parameters?
 
-pub fn parse(source_file: ParsedSourceFile, config: TypeScriptConfiguration) -> PrintItem {
+pub fn parse(source_file: ParsedSourceFile, config: TypeScriptConfiguration) -> PrintItems {
     let module = Node::Module(&source_file.module);
     let mut context = Context::new(
         config,
@@ -22,22 +22,22 @@ pub fn parse(source_file: ParsedSourceFile, config: TypeScriptConfiguration) -> 
         module,
         source_file.info
     );
-    let mut items = Vec::new();
-    items.push(parse_node(Node::Module(&source_file.module), &mut context));
-    items.push(if_true(
+    let mut items = PrintItems::new();
+    items.extend(parse_node(Node::Module(&source_file.module), &mut context));
+    items.extend(if_true(
         "endOfFileNewLine",
         |context| Some(context.writer_info.column_number > 0 || context.writer_info.line_number > 0),
-        PrintItem::NewLine
+        Signal::NewLine.into()
     ));
-    items.into()
+    items
 }
 
-fn parse_node<'a>(node: Node<'a>, context: &mut Context<'a>) -> PrintItem {
+fn parse_node<'a>(node: Node<'a>, context: &mut Context<'a>) -> PrintItems {
     parse_node_with_inner_parse(node, context, |items| items)
 }
 
-fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, inner_parse: impl Fn(PrintItem) -> PrintItem + Clone + 'static) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, inner_parse: impl Fn(PrintItems) -> PrintItems + Clone + 'static) -> PrintItems {
+    let mut items = PrintItems::new();
 
     // println!("Node kind: {:?}", node.kind());
     // println!("Text: {:?}", node.text(context));
@@ -54,11 +54,9 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
     let leading_comments = context.comments.leading_comments_with_previous(node_lo);
     let has_ignore_comment = get_has_ignore_comment(&leading_comments, &node_lo, context);
 
-    if let Some(parsed_comments) = parse_comments_as_leading(&node_span, leading_comments, context) {
-        items.push(parsed_comments);
-    }
+    items.extend(parse_comments_as_leading(&node_span, leading_comments, context));
 
-    items.push(if has_ignore_comment {
+    items.extend(if has_ignore_comment {
         parser_helpers::parse_raw_string(&node.text(context))
     } else {
         inner_parse(parse_node_inner(node, context))
@@ -66,17 +64,15 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
 
     if node_hi != parent_hi || context.parent().kind() == NodeKind::Module {
         let trailing_comments = context.comments.trailing_comments_with_previous(node_hi);
-        if let Some(parsed_comments) = parse_comments_as_trailing(&node_span, trailing_comments, context) {
-            items.push(parsed_comments);
-        }
+        items.extend(parse_comments_as_trailing(&node_span, trailing_comments, context));
     }
 
     // pop info
     context.current_node = context.parent_stack.pop();
 
-    return items.into();
+    return items;
 
-    fn parse_node_inner<'a>(node: Node<'a>, context: &mut Context<'a>) -> PrintItem {
+    fn parse_node_inner<'a>(node: Node<'a>, context: &mut Context<'a>) -> PrintItems {
         match node {
             /* class */
             Node::ClassMethod(node) => parse_class_method(node, context),
@@ -300,7 +296,7 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
 
 /* class */
 
-fn parse_class_method<'a>(node: &'a ClassMethod, context: &mut Context<'a>) -> PrintItem {
+fn parse_class_method<'a>(node: &'a ClassMethod, context: &mut Context<'a>) -> PrintItems {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: Some(&node.function.decorators),
         accessibility: node.accessibility,
@@ -318,35 +314,35 @@ fn parse_class_method<'a>(node: &'a ClassMethod, context: &mut Context<'a>) -> P
     }, context);
 }
 
-fn parse_class_prop<'a>(node: &'a ClassProp, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_decorators(&node.decorators, false, context));
+fn parse_class_prop<'a>(node: &'a ClassProp, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_decorators(&node.decorators, false, context));
     if let Some(accessibility) = node.accessibility {
-        items.push(format!("{} ", accessibility_to_str(&accessibility)).into());
+        items.push_str(&format!("{} ", accessibility_to_str(&accessibility)));
     }
-    if node.is_static { items.push("static ".into()); }
-    if node.is_abstract { items.push("abstract ".into()); }
-    if node.readonly { items.push("readonly ".into()); }
-    if node.computed { items.push("[".into()); }
-    items.push(parse_node((&node.key).into(), context));
-    if node.computed { items.push("]".into()); }
-    if node.is_optional { items.push("?".into()); }
-    if node.definite { items.push("!".into()); }
-    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    if node.is_static { items.push_str("static "); }
+    if node.is_abstract { items.push_str("abstract "); }
+    if node.readonly { items.push_str("readonly "); }
+    if node.computed { items.push_str("["); }
+    items.extend(parse_node((&node.key).into(), context));
+    if node.computed { items.push_str("]"); }
+    if node.is_optional { items.push_str("?"); }
+    if node.definite { items.push_str("!"); }
+    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
 
     if let Some(value) = &node.value {
-        items.push(" = ".into());
-        items.push(parse_node(value.into(), context));
+        items.push_str(" = ");
+        items.extend(parse_node(value.into(), context));
     }
 
     if context.config.class_property_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    return items.into();
+    return items;
 }
 
-fn parse_constructor<'a>(node: &'a Constructor, context: &mut Context<'a>) -> PrintItem {
+fn parse_constructor<'a>(node: &'a Constructor, context: &mut Context<'a>) -> PrintItems {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: None,
         accessibility: node.accessibility,
@@ -364,44 +360,44 @@ fn parse_constructor<'a>(node: &'a Constructor, context: &mut Context<'a>) -> Pr
     }, context);
 }
 
-fn parse_decorator<'a>(node: &'a Decorator, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("@".into());
-    items.push(parse_node((&node.expr).into(), context));
-    return items.into();
+fn parse_decorator<'a>(node: &'a Decorator, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("@");
+    items.extend(parse_node((&node.expr).into(), context));
+    return items;
 }
 
-fn parse_parameter_prop<'a>(node: &'a TsParamProp, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_decorators(&node.decorators, true, context));
+fn parse_parameter_prop<'a>(node: &'a TsParamProp, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_decorators(&node.decorators, true, context));
     if let Some(accessibility) = node.accessibility {
-        items.push(format!("{} ", accessibility_to_str(&accessibility)).into());
+        items.push_str(&format!("{} ", accessibility_to_str(&accessibility)));
     }
-    if node.readonly { items.push("readonly ".into()); }
-    items.push(parse_node((&node.param).into(), context));
-    return items.into();
+    if node.readonly { items.push_str("readonly "); }
+    items.extend(parse_node((&node.param).into(), context));
+    return items;
 }
 
 /* clauses */
 
-fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> PrintItem {
+fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> PrintItems {
     // a bit overkill since the param will currently always just be an identifer
     let start_header_info = Info::new("catchClauseHeaderStart");
     let end_header_info = Info::new("catchClauseHeaderEnd");
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push(start_header_info.clone().into());
-    items.push("catch".into());
+    items.push_info(start_header_info.clone());
+    items.push_str("catch");
 
     if let Some(param) = &node.param {
-        items.push(" (".into());
-        items.push(parse_node(param.into(), context));
-        items.push(")".into());
+        items.push_str(" (");
+        items.extend(parse_node(param.into(), context));
+        items.push_str(")");
     }
-    items.push(end_header_info.clone().into());
+    items.push_info(end_header_info.clone());
 
     // not conditional... required
-    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: UseBraces::Always,
@@ -413,40 +409,40 @@ fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> P
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
 
-    return items.into();
+    return items;
 }
 
 /* common */
 
-fn parse_computed_prop_name<'a>(node: &'a ComputedPropName, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("[".into());
-    items.push(parse_node((&node.expr).into(), context));
-    items.push("]".into());
-    return items.into();
+fn parse_computed_prop_name<'a>(node: &'a ComputedPropName, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("[");
+    items.extend(parse_node((&node.expr).into(), context));
+    items.push_str("]");
+    return items;
 }
 
-fn parse_identifier<'a>(node: &'a Ident, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push((&node.sym as &str).into());
+fn parse_identifier<'a>(node: &'a Ident, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str((&node.sym as &str));
 
     if node.optional {
-        items.push("?".into());
+        items.push_str("?");
     }
     if let Node::VarDeclarator(node) = context.parent() {
         if node.definite {
-            items.push("!".into());
+            items.push_str("!");
         }
     }
 
-    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
 
-    return items.into();
+    return items;
 }
 
 /* declarations */
 
-fn parse_class_decl<'a>(node: &'a ClassDecl, context: &mut Context<'a>) -> PrintItem {
+fn parse_class_decl<'a>(node: &'a ClassDecl, context: &mut Context<'a>) -> PrintItems {
     return parse_class_decl_or_expr(ClassDeclOrExpr {
         span: node.class.span,
         decorators: &node.class.decorators,
@@ -478,54 +474,54 @@ struct ClassDeclOrExpr<'a> {
     brace_position: BracePosition,
 }
 
-fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
     let parent_kind = context.parent().kind();
     if parent_kind != NodeKind::ExportDecl && parent_kind != NodeKind::ExportDefaultDecl {
-        items.push(parse_decorators(node.decorators, node.is_class_expr, context));
+        items.extend(parse_decorators(node.decorators, node.is_class_expr, context));
     }
     let start_header_info = Info::new("startHeader");
     let parsed_header = {
-        let mut items = Vec::new();
-        items.push(start_header_info.clone().into());
+        let mut items = PrintItems::new();
+        items.push_info(start_header_info.clone());
 
-        if node.is_declare { items.push("declare ".into()); }
-        if node.is_abstract { items.push("abstract ".into()); }
+        if node.is_declare { items.push_str("declare "); }
+        if node.is_abstract { items.push_str("abstract "); }
 
-        items.push("class".into());
+        items.push_str("class");
 
         if let Some(ident) = node.ident {
-            items.push(" ".into());
-            items.push(parse_node(ident, context));
+            items.push_str(" ");
+            items.extend(parse_node(ident, context));
         }
         if let Some(type_params) = node.type_params {
-            items.push(parse_node(type_params, context));
+            items.extend(parse_node(type_params, context));
         }
         if let Some(super_class) = node.super_class {
-            items.push(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_header_info.clone(), None).into());
-            items.push(conditions::indent_if_start_of_line({
-                let mut items = Vec::new();
-                items.push("extends ".into());
-                items.push(parse_node(super_class, context));
+            items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_header_info.clone(), None));
+            items.push_condition(conditions::indent_if_start_of_line({
+                let mut items = PrintItems::new();
+                items.push_str("extends ");
+                items.extend(parse_node(super_class, context));
                 if let Some(super_type_params) = node.super_type_params {
-                    items.push(parse_node(super_type_params, context));
+                    items.extend(parse_node(super_type_params, context));
                 }
-                items.into()
-            }).into());
+                items
+            }));
         }
-        items.push(parse_extends_or_implements("implements", node.implements, start_header_info.clone(), context));
-        items.into()
+        items.extend(parse_extends_or_implements("implements", node.implements, start_header_info.clone(), context));
+        items
     };
 
     if node.is_class_expr {
-        items.push(conditions::indent_if_start_of_line(parsed_header).into());
+        items.push_condition(conditions::indent_if_start_of_line(parsed_header));
     } else {
-        items.push(parsed_header);
+        items.extend(parsed_header);
     }
 
     // parse body
-    items.push(parse_membered_body(ParseMemberedBodyOptions {
+    items.extend(parse_membered_body(ParseMemberedBodyOptions {
         span: node.span,
         members: node.members,
         start_header_info: Some(start_header_info),
@@ -536,52 +532,52 @@ fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context
         trailing_commas: None,
     }, context));
 
-    return items.into();
+    return items;
 }
 
-fn parse_export_decl<'a>(node: &'a ExportDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_export_decl<'a>(node: &'a ExportDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if let Decl::Class(class_decl) = &node.decl {
-        items.push(parse_decorators(&class_decl.class.decorators, false, context));
+        items.extend(parse_decorators(&class_decl.class.decorators, false, context));
     }
-    items.push("export ".into());
-    items.push(parse_node((&node.decl).into(), context));
-    items.into()
+    items.push_str("export ");
+    items.extend(parse_node((&node.decl).into(), context));
+    items
 }
 
-fn parse_export_default_decl<'a>(node: &'a ExportDefaultDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_export_default_decl<'a>(node: &'a ExportDefaultDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if let DefaultDecl::Class(class_expr) = &node.decl {
-        items.push(parse_decorators(&class_expr.class.decorators, false, context));
+        items.extend(parse_decorators(&class_expr.class.decorators, false, context));
     }
-    items.push("export default ".into());
-    items.push(parse_node((&node.decl).into(), context));
-    items.into()
+    items.push_str("export default ");
+    items.extend(parse_node((&node.decl).into(), context));
+    items
 }
 
-fn parse_export_default_expr<'a>(node: &'a ExportDefaultExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("export default ".into());
-    items.push(parse_node((&node.expr).into(), context));
-    if context.config.export_default_expression_semi_colon { items.push(";".into()); }
-    items.into()
+fn parse_export_default_expr<'a>(node: &'a ExportDefaultExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("export default ");
+    items.extend(parse_node((&node.expr).into(), context));
+    if context.config.export_default_expression_semi_colon { items.push_str(";"); }
+    items
 }
 
-fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> PrintItem {
+fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> PrintItems {
     let start_header_info = Info::new("startHeader");
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
     // header
-    items.push(start_header_info.clone().into());
+    items.push_info(start_header_info.clone());
 
-    if node.declare { items.push("declare ".into()); }
-    if node.is_const { items.push("const ".into()); }
-    items.push("enum ".into());
-    items.push(parse_node((&node.id).into(), context));
+    if node.declare { items.push_str("declare "); }
+    if node.is_const { items.push_str("const "); }
+    items.push_str("enum ");
+    items.extend(parse_node((&node.id).into(), context));
 
     // body
     let member_spacing = context.config.enum_declaration_member_spacing;
-    items.push(parse_membered_body(ParseMemberedBodyOptions {
+    items.extend(parse_membered_body(ParseMemberedBodyOptions {
         span: node.span,
         members: node.members.iter().map(|x| x.into()).collect(),
         start_header_info: Some(start_header_info),
@@ -596,31 +592,31 @@ fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> Print
         trailing_commas: Some(context.config.enum_declaration_trailing_commas),
     }, context));
 
-    return items.into();
+    return items;
 }
 
-fn parse_enum_member<'a>(node: &'a TsEnumMember, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.id).into(), context));
+fn parse_enum_member<'a>(node: &'a TsEnumMember, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.id).into(), context));
 
     if let Some(init) = &node.init {
-        items.push(match init.kind() {
-            NodeKind::Number | NodeKind::Str => PrintItem::SpaceOrNewLine,
-            _ => " ".into(),
-        });
+        match init.kind() {
+            NodeKind::Number | NodeKind::Str => items.push_signal(Signal::SpaceOrNewLine),
+            _ => items.push_str(" "),
+        };
 
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
-            items.push("= ".into());
-            items.push(parse_node(init.into(), context));
-            items.into()
-        }).into());
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str("= ");
+            items.extend(parse_node(init.into(), context));
+            items
+        }));
     }
 
-    items.into()
+    items
 }
 
-fn parse_export_named_decl<'a>(node: &'a NamedExport, context: &mut Context<'a>) -> PrintItem {
+fn parse_export_named_decl<'a>(node: &'a NamedExport, context: &mut Context<'a>) -> PrintItems {
     // fill specifiers
     let mut default_export: Option<&DefaultExportSpecifier> = None;
     let mut namespace_export: Option<&NamespaceExportSpecifier> = None;
@@ -635,37 +631,37 @@ fn parse_export_named_decl<'a>(node: &'a NamedExport, context: &mut Context<'a>)
     }
 
     // parse
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push("export ".into());
+    items.push_str("export ");
 
     if let Some(default_export) = default_export {
-        items.push(parse_node(default_export.into(), context));
+        items.extend(parse_node(default_export.into(), context));
     } else if !named_exports.is_empty() {
-        items.push(parse_named_import_or_export_specifiers(
+        items.extend(parse_named_import_or_export_specifiers(
             NamedImportOrExportDeclaration::Export(node),
             named_exports.into_iter().map(|x| x.into()).collect(),
             context
         ));
     } else if let Some(namespace_export) = namespace_export {
-        items.push(parse_node(namespace_export.into(), context));
+        items.extend(parse_node(namespace_export.into(), context));
     } else {
-        items.push("{}".into());
+        items.push_str("{}");
     }
 
     if let Some(src) = &node.src {
-        items.push(" from ".into());
-        items.push(parse_node(src.into(), context));
+        items.push_str(" from ");
+        items.extend(parse_node(src.into(), context));
     }
 
     if context.config.export_named_declaration_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    items.into()
+    items
 }
 
-fn parse_function_decl<'a>(node: &'a FnDecl, context: &mut Context<'a>) -> PrintItem {
+fn parse_function_decl<'a>(node: &'a FnDecl, context: &mut Context<'a>) -> PrintItems {
     parse_function_decl_or_expr(FunctionDeclOrExprNode {
         is_func_decl: true,
         ident: Some(&node.ident),
@@ -681,24 +677,24 @@ struct FunctionDeclOrExprNode<'a> {
     func: &'a Function,
 }
 
-fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_header_info = Info::new("functionHeaderStart");
     let func = node.func;
 
-    items.push(start_header_info.clone().into());
-    if node.declare { items.push("declare ".into()); }
-    if func.is_async { items.push("async ".into()); }
-    items.push("function".into());
-    if func.is_generator { items.push("*".into()); }
+    items.push_info(start_header_info.clone());
+    if node.declare { items.push_str("declare "); }
+    if func.is_async { items.push_str("async "); }
+    items.push_str("function");
+    if func.is_generator { items.push_str("*"); }
     if let Some(ident) = node.ident {
-        items.push(" ".into());
-        items.push(parse_node(ident.into(), context));
+        items.push_str(" ");
+        items.extend(parse_node(ident.into(), context));
     }
-    if let Some(type_params) = &func.type_params { items.push(parse_node(type_params.into(), context)); }
-    if get_use_space_before_parens(node.is_func_decl, context) { items.push(" ".into()); }
+    if let Some(type_params) = &func.type_params { items.extend(parse_node(type_params.into(), context)); }
+    if get_use_space_before_parens(node.is_func_decl, context) { items.push_str(" "); }
 
-    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: func.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: if node.is_func_decl {
             context.config.function_declaration_force_multi_line_parameters
@@ -720,20 +716,20 @@ fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &m
         };
         let open_brace_token = context.token_finder.get_first_open_brace_token_within(&body);
 
-        items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+        items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
             brace_position: brace_position,
             open_brace_token: open_brace_token,
             start_header_info: Some(start_header_info),
         }, context));
 
-        items.push(parse_node(body.into(), context));
+        items.extend(parse_node(body.into(), context));
     } else {
         if context.config.function_declaration_semi_colon {
-            items.push(";".into());
+            items.push_str(";");
         }
     }
 
-    return items.into();
+    return items;
 
     fn get_use_space_before_parens(is_func_decl: bool, context: &mut Context) -> bool {
         if is_func_decl {
@@ -744,7 +740,7 @@ fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &m
     }
 }
 
-fn parse_import_decl<'a>(node: &'a ImportDecl, context: &mut Context<'a>) -> PrintItem {
+fn parse_import_decl<'a>(node: &'a ImportDecl, context: &mut Context<'a>) -> PrintItems {
     // fill specifiers
     let mut default_import: Option<&ImportDefault> = None;
     let mut namespace_import: Option<&ImportStarAs> = None;
@@ -758,69 +754,69 @@ fn parse_import_decl<'a>(node: &'a ImportDecl, context: &mut Context<'a>) -> Pri
         }
     }
 
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
     let has_from = default_import.is_some() || namespace_import.is_some() || !named_imports.is_empty();
-    items.push("import ".into());
+    items.push_str("import ");
 
     if let Some(default_import) = default_import {
-        items.push(parse_node(default_import.into(), context));
+        items.extend(parse_node(default_import.into(), context));
         if namespace_import.is_some() || !named_imports.is_empty() {
-            items.push(", ".into());
+            items.push_str(", ");
         }
     }
     if let Some(namespace_import) = namespace_import {
-        items.push(parse_node(namespace_import.into(), context));
+        items.extend(parse_node(namespace_import.into(), context));
     }
-    items.push(parse_named_import_or_export_specifiers(
+    items.extend(parse_named_import_or_export_specifiers(
         NamedImportOrExportDeclaration::Import(node),
         named_imports.into_iter().map(|x| x.into()).collect(),
         context
     ));
 
-    if has_from { items.push(" from ".into()); }
+    if has_from { items.push_str(" from "); }
 
-    items.push(parse_node((&node.src).into(), context));
+    items.extend(parse_node((&node.src).into(), context));
 
     if context.config.import_declaration_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    return items.into();
+    return items;
 }
 
-fn parse_import_equals_decl<'a>(node: &'a TsImportEqualsDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_import_equals_decl<'a>(node: &'a TsImportEqualsDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if node.is_export {
-        items.push("export ".into());
+        items.push_str("export ");
     }
 
-    items.push("import ".into());
-    items.push(parse_node((&node.id).into(), context));
-    items.push(" = ".into());
-    items.push(parse_node((&node.module_ref).into(), context));
+    items.push_str("import ");
+    items.extend(parse_node((&node.id).into(), context));
+    items.push_str(" = ");
+    items.extend(parse_node((&node.module_ref).into(), context));
 
-    if context.config.import_equals_declaration_semi_colon { items.push(";".into()); }
+    if context.config.import_equals_declaration_semi_colon { items.push_str(";"); }
 
-    return items.into();
+    return items;
 }
 
-fn parse_interface_decl<'a>(node: &'a TsInterfaceDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_interface_decl<'a>(node: &'a TsInterfaceDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_header_info = Info::new("startHeader");
-    items.push(start_header_info.clone().into());
+    items.push_info(start_header_info.clone());
     context.store_info_for_node(&node, start_header_info.clone());
 
-    if node.declare { items.push("declare ".into()); }
-    items.push("interface ".into());
-    items.push(parse_node((&node.id).into(), context));
-    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
-    items.push(parse_extends_or_implements("extends", node.extends.iter().map(|x| x.into()).collect(), start_header_info, context));
-    items.push(parse_node((&node.body).into(), context));
+    if node.declare { items.push_str("declare "); }
+    items.push_str("interface ");
+    items.extend(parse_node((&node.id).into(), context));
+    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
+    items.extend(parse_extends_or_implements("extends", node.extends.iter().map(|x| x.into()).collect(), start_header_info, context));
+    items.extend(parse_node((&node.body).into(), context));
 
-    return items.into();
+    return items;
 }
 
-fn parse_module_decl<'a>(node: &'a TsModuleDecl, context: &mut Context<'a>) -> PrintItem {
+fn parse_module_decl<'a>(node: &'a TsModuleDecl, context: &mut Context<'a>) -> PrintItems {
     parse_module_or_namespace_decl(ModuleOrNamespaceDecl {
         span: node.span,
         declare: node.declare,
@@ -830,7 +826,7 @@ fn parse_module_decl<'a>(node: &'a TsModuleDecl, context: &mut Context<'a>) -> P
     }, context)
 }
 
-fn parse_namespace_decl<'a>(node: &'a TsNamespaceDecl, context: &mut Context<'a>) -> PrintItem {
+fn parse_namespace_decl<'a>(node: &'a TsNamespaceDecl, context: &mut Context<'a>) -> PrintItems {
     parse_module_or_namespace_decl(ModuleOrNamespaceDecl {
         span: node.span,
         declare: node.declare,
@@ -848,32 +844,32 @@ struct ModuleOrNamespaceDecl<'a> {
     pub body: Option<&'a TsNamespaceBody>,
 }
 
-fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
     let start_header_info = Info::new("startHeader");
-    items.push(start_header_info.clone().into());
+    items.push_info(start_header_info.clone());
 
-    if node.declare { items.push("declare ".into()); }
+    if node.declare { items.push_str("declare "); }
     if node.global {
-        items.push("global".into());
-        // items.push(parse_node(node.id.into(), context));
+        items.push_str("global");
+        // items.extend(parse_node(node.id.into(), context));
     } else {
         let has_namespace_keyword = context.token_finder.get_char_at(&node.span.lo()) == 'n';
-        items.push(if has_namespace_keyword { "namespace " } else { "module " }.into());
+        items.push_str(if has_namespace_keyword { "namespace " } else { "module " });
     }
 
-    items.push(parse_node(node.id.into(), context));
-    items.push(parse_body(node.body, start_header_info, context));
+    items.extend(parse_node(node.id.into(), context));
+    items.extend(parse_body(node.body, start_header_info, context));
 
-    return items.into();
+    return items;
 
-    fn parse_body<'a>(body: Option<&'a TsNamespaceBody>, start_header_info: Info, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn parse_body<'a>(body: Option<&'a TsNamespaceBody>, start_header_info: Info, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
         if let Some(body) = &body {
             match body {
                 TsNamespaceBody::TsModuleBlock(block) => {
-                    items.push(parse_membered_body(ParseMemberedBodyOptions {
+                    items.extend(parse_membered_body(ParseMemberedBodyOptions {
                         span: block.span,
                         members: block.body.iter().map(|x| x.into()).collect(),
                         start_header_info: Some(start_header_info),
@@ -885,42 +881,42 @@ fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: 
                     }, context));
                 },
                 TsNamespaceBody::TsNamespaceDecl(decl) => {
-                    items.push(".".into());
-                    items.push(parse_node((&decl.id).into(), context));
-                    items.push(parse_body(Some(&*decl.body), start_header_info, context));
+                    items.push_str(".");
+                    items.extend(parse_node((&decl.id).into(), context));
+                    items.extend(parse_body(Some(&*decl.body), start_header_info, context));
                 }
             }
         }
         else if context.config.module_declaration_semi_colon {
-            items.push(";".into());
+            items.push_str(";");
         }
 
-        return items.into();
+        return items;
     }
 }
 
-fn parse_type_alias<'a>(node: &'a TsTypeAliasDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    if node.declare { items.push("declare ".into()); }
-    items.push("type ".into());
-    items.push(parse_node((&node.id).into(), context));
+fn parse_type_alias<'a>(node: &'a TsTypeAliasDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    if node.declare { items.push_str("declare "); }
+    items.push_str("type ");
+    items.extend(parse_node((&node.id).into(), context));
     if let Some(type_params) = &node.type_params {
-        items.push(parse_node(type_params.into(), context));
+        items.extend(parse_node(type_params.into(), context));
     }
-    items.push(" = ".into());
-    items.push(parse_node((&node.type_ann).into(), context));
+    items.push_str(" = ");
+    items.extend(parse_node((&node.type_ann).into(), context));
 
-    if context.config.type_alias_semi_colon { items.push(";".into()); }
+    if context.config.type_alias_semi_colon { items.push_str(";"); }
 
-    return items.into();
+    return items;
 }
 
 /* exports */
 
-fn parse_named_import_or_export_specifiers<'a>(parent_decl: NamedImportOrExportDeclaration<'a>, specifiers: Vec<Node<'a>>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_named_import_or_export_specifiers<'a>(parent_decl: NamedImportOrExportDeclaration<'a>, specifiers: Vec<Node<'a>>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if specifiers.is_empty() {
-        return items.into();
+        return items;
     }
 
     let use_space = get_use_space(&parent_decl, context);
@@ -929,35 +925,35 @@ fn parse_named_import_or_export_specifiers<'a>(parent_decl: NamedImportOrExportD
         &specifiers[0],
         context
     );
-    let brace_separator = if use_new_lines { PrintItem::NewLine } else { if use_space { " ".into() } else { "".into() } }.into_rc();
+    let brace_separator: PrintItems = if use_new_lines { Signal::NewLine.into() } else if use_space { " ".into() } else { "".into() };
 
-    items.push("{".into());
-    items.push(brace_separator.clone().into());
+    items.push_str("{");
+    items.extend(brace_separator.clone());
 
     let specifiers = {
-        let mut items = Vec::new();
+        let mut items = PrintItems::new();
         for (i, specifier) in specifiers.into_iter().enumerate() {
             if i > 0 {
-                items.push(",".into());
-                items.push(if use_new_lines { PrintItem::NewLine } else { PrintItem::SpaceOrNewLine });
+                items.push_str(",");
+                items.push_signal(if use_new_lines { Signal::NewLine } else { Signal::SpaceOrNewLine });
             }
 
             let parsed_specifier = parse_node(specifier.into(), context);
-            items.push(if use_new_lines {
-                parsed_specifier
+            if use_new_lines {
+                items.extend(parsed_specifier)
             } else {
-                conditions::indent_if_start_of_line(parser_helpers::new_line_group(parsed_specifier)).into()
-            });
+                items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parsed_specifier)));
+            }
         }
-        items.into()
+        items
     };
 
-    items.push(if use_new_lines { parser_helpers::with_indent(specifiers) } else { specifiers });
+    items.extend(if use_new_lines { parser_helpers::with_indent(specifiers) } else { specifiers });
 
-    items.push(brace_separator.into());
-    items.push("}".into());
+    items.extend(brace_separator);
+    items.push_str("}");
 
-    return items.into();
+    return items;
 
     fn get_use_space(parent_decl: &NamedImportOrExportDeclaration, context: &mut Context) -> bool {
         match parent_decl {
@@ -969,7 +965,7 @@ fn parse_named_import_or_export_specifiers<'a>(parent_decl: NamedImportOrExportD
 
 /* expressions */
 
-fn parse_array_expr<'a>(node: &'a ArrayLit, context: &mut Context<'a>) -> PrintItem {
+fn parse_array_expr<'a>(node: &'a ArrayLit, context: &mut Context<'a>) -> PrintItems {
     parse_array_like_nodes(ParseArrayLikeNodesOptions {
         parent_span: node.span,
         elements: node.elems.iter().map(|x| x.as_ref().map(|elem| elem.into())).collect(),
@@ -977,17 +973,17 @@ fn parse_array_expr<'a>(node: &'a ArrayLit, context: &mut Context<'a>) -> PrintI
     }, context)
 }
 
-fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let header_start_info = Info::new("arrowFunctionExpressionHeaderStart");
     let should_use_params = get_should_use_params(&node, context);
 
-    items.push(header_start_info.clone().into());
-    if node.is_async { items.push("async ".into()); }
-    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
+    items.push_info(header_start_info.clone());
+    if node.is_async { items.push_str("async "); }
+    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
 
     if should_use_params {
-        items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+        items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
             nodes: node.params.iter().map(|node| node.into()).collect(),
             force_multi_line_when_multiple_lines: context.config.arrow_function_expression_force_multi_line_parameters,
             custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -997,24 +993,24 @@ fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> 
             }, context)),
         }, context));
     } else {
-        items.push(parse_node(node.params.iter().next().unwrap().into(), context));
+        items.extend(parse_node(node.params.iter().next().unwrap().into(), context));
     }
 
-    items.push(" =>".into());
+    items.push_str(" =>");
 
     let open_brace_token = match &node.body {
         BlockStmtOrExpr::BlockStmt(stmt) => context.token_finder.get_first_open_brace_token_within(&stmt),
         _ => None,
     };
-    items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+    items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
         brace_position: context.config.arrow_function_expression_brace_position,
         open_brace_token: open_brace_token,
         start_header_info: Some(header_start_info),
     }, context));
 
-    items.push(parse_node((&node.body).into(), context));
+    items.extend(parse_node((&node.body).into(), context));
 
-    return items.into();
+    return items;
 
     fn get_should_use_params(node: &ArrowExpr, context: &mut Context) -> bool {
         let requires_parens = node.params.len() != 1 || node.return_type.is_some() || is_first_param_not_identifier_or_has_type_annotation(&node.params);
@@ -1047,44 +1043,44 @@ fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> 
     }
 }
 
-fn parse_as_expr<'a>(node: &'a TsAsExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.expr).into(), context));
-    items.push(" as ".into());
-    items.push(conditions::with_indent_if_start_of_line_indented(parse_node((&node.type_ann).into(), context)).into());
-    items.into()
+fn parse_as_expr<'a>(node: &'a TsAsExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.expr).into(), context));
+    items.push_str(" as ");
+    items.push_condition(conditions::with_indent_if_start_of_line_indented(parse_node((&node.type_ann).into(), context)));
+    items
 }
 
-fn parse_const_assertion<'a>(node: &'a TsConstAssertion, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.expr).into(), context));
-    items.push(" as const".into());
-    items.into()
+fn parse_const_assertion<'a>(node: &'a TsConstAssertion, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.expr).into(), context));
+    items.push_str(" as const");
+    items
 }
 
-fn parse_assignment_expr<'a>(node: &'a AssignExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.left).into(), context));
-    items.push(format!(" {} ", node.op).into());
-    items.push(conditions::with_indent_if_start_of_line_indented(parse_node((&node.right).into(), context)).into());
-    items.into()
+fn parse_assignment_expr<'a>(node: &'a AssignExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.left).into(), context));
+    items.push_str(&format!(" {} ", node.op));
+    items.push_condition(conditions::with_indent_if_start_of_line_indented(parse_node((&node.right).into(), context)));
+    items
 }
 
-fn parse_await_expr<'a>(node: &'a AwaitExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("await ".into());
-    items.push(parse_node((&node.arg).into(), context));
-    items.into()
+fn parse_await_expr<'a>(node: &'a AwaitExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("await ");
+    items.extend(parse_node((&node.arg).into(), context));
+    items
 }
 
-fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintItems {
     return if is_expression_breakable(&node.op) {
         inner_parse(node, context)
     } else {
         new_line_group(inner_parse(node, context))
     };
 
-    fn inner_parse<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintItem {
+    fn inner_parse<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintItems {
         // todo: clean this up
         let operator_token = context.token_finder.get_first_operator_after(&node.left, node.op.as_str()).unwrap();
         let operator_position = get_operator_position(&node, &operator_token, context);
@@ -1097,10 +1093,10 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
         let use_new_lines = node_helpers::get_use_new_lines_for_nodes(node_left, node_right, context);
         let top_most_info = get_or_set_top_most_info(top_most_expr_start, is_top_most, context);
         let indent_disabled = context.get_disable_indent_for_next_bin_expr();
-        let mut items = Vec::new();
+        let mut items = PrintItems::new();
 
         if is_top_most {
-            items.push(top_most_info.clone().into());
+            items.push_info(top_most_info.clone());
         }
 
         let node_left_node = Node::from(node_left);
@@ -1108,31 +1104,26 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
             context.mark_disable_indent_for_next_bin_expr();
         }
 
-        items.push(indent_if_necessary(node_left.lo(), top_most_expr_start, top_most_info.clone(), indent_disabled, {
-            new_line_group_if_necessary(&node_left, parse_node_with_inner_parse(node_left_node, context, move |item| {
+        items.extend(indent_if_necessary(node_left.lo(), top_most_expr_start, top_most_info.clone(), indent_disabled, {
+            new_line_group_if_necessary(&node_left, parse_node_with_inner_parse(node_left_node, context, move |mut items| {
                 if operator_position == OperatorPosition::SameLine {
-                    let mut items = vec![item];
                     if use_space_surrounding_operator {
-                        items.push(" ".into());
+                        items.push_str(" ");
                     }
-                    items.push(node_op.as_str().into());
-                    items.into()
-                } else {
-                    item
+                    items.push_str(node_op.as_str());
                 }
+                items
             }))
         }));
 
-        if let Some(parsed_comments) = parse_comments_as_trailing(&operator_token, operator_token.trailing_comments(context), context) {
-            items.push(parsed_comments);
-        }
+        items.extend(parse_comments_as_trailing(&operator_token, operator_token.trailing_comments(context), context));
 
-        items.push(if use_new_lines {
-            PrintItem::NewLine
+        items.push_signal(if use_new_lines {
+            Signal::NewLine
         } else if use_space_surrounding_operator {
-            PrintItem::SpaceOrNewLine
+            Signal::SpaceOrNewLine
         } else {
-            PrintItem::PossibleNewLine
+            Signal::PossibleNewLine
         });
 
         let node_right_node = Node::from(node_right);
@@ -1140,27 +1131,25 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
             context.mark_disable_indent_for_next_bin_expr();
         }
 
-        items.push(indent_if_necessary(node_right.lo(), top_most_expr_start, top_most_info, indent_disabled, {
-            let mut items = Vec::new();
+        items.extend(indent_if_necessary(node_right.lo(), top_most_expr_start, top_most_info, indent_disabled, {
+            let mut items = PrintItems::new();
             let use_new_line_group = get_use_new_line_group(&node_right);
-            if let Some(parsed_comments) = parse_comments_as_leading(node_right, operator_token.leading_comments(context), context) {
-                items.push(parsed_comments);
-            }
-            items.push(parse_node_with_inner_parse(node_right.into(), context, move |item| {
-                let mut items = Vec::new();
+            items.extend(parse_comments_as_leading(node_right, operator_token.leading_comments(context), context));
+            items.extend(parse_node_with_inner_parse(node_right.into(), context, move |items| {
+                let mut new_items = PrintItems::new();
                 if operator_position == OperatorPosition::NextLine {
-                    items.push(node_op.as_str().into());
+                    new_items.push_str(node_op.as_str());
                     if use_space_surrounding_operator {
-                        items.push(" ".into());
+                        new_items.push_str(" ");
                     }
                 }
-                items.push(if use_new_line_group { new_line_group(item) } else { item });
-                items.into()
+                new_items.extend(if use_new_line_group { new_line_group(items) } else { items });
+                new_items
             }));
-            items.into()
+            items
         }));
 
-        return items.into();
+        return items;
     }
 
     fn indent_if_necessary(
@@ -1168,9 +1157,8 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
         top_most_expr_start: BytePos,
         top_most_info: Info,
         indent_disabled: bool,
-        items: PrintItem
-    ) -> PrintItem {
-        let items = items.into_rc();
+        items: PrintItems
+    ) -> PrintItems {
         let is_left_most_node = top_most_expr_start == current_node_start;
         Condition::new("indentIfNecessaryForBinaryExpressions", ConditionProperties {
             condition: Box::new(move |condition_context| {
@@ -1184,7 +1172,7 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
         }).into()
     }
 
-    fn new_line_group_if_necessary(expr: &Expr, items: PrintItem) -> PrintItem {
+    fn new_line_group_if_necessary(expr: &Expr, items: PrintItems) -> PrintItems {
         match get_use_new_line_group(expr) {
             true => parser_helpers::new_line_group(items),
             false => items,
@@ -1260,53 +1248,53 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
     }
 }
 
-fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItems {
     return if is_test_library_call_expr(&node, context) {
         parse_test_library_call_expr(node, context)
     } else {
         inner_parse(node, context)
     };
 
-    fn inner_parse<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn inner_parse<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
 
-        items.push(parse_node((&node.callee).into(), context));
+        items.extend(parse_node((&node.callee).into(), context));
 
         if let Some(type_args) = &node.type_args {
-            items.push(parse_node(type_args.into(), context));
+            items.extend(parse_node(type_args.into(), context));
         }
 
         if is_optional(context) {
-            items.push("?.".into());
+            items.push_str("?.");
         }
 
-        items.push(conditions::with_indent_if_start_of_line_indented(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+        items.push_condition(conditions::with_indent_if_start_of_line_indented(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
             nodes: node.args.iter().map(|node| node.into()).collect(),
             force_multi_line_when_multiple_lines: context.config.call_expression_force_multi_line_arguments,
             custom_close_paren: None,
-        }, context)).into());
+        }, context)));
 
-        items.into()
+        items
     }
 
-    fn parse_test_library_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
-        items.push(parse_test_library_callee(&node.callee, context));
-        items.push(parse_test_library_arguments(&node.args, context));
-        return items.into();
+    fn parse_test_library_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.extend(parse_test_library_callee(&node.callee, context));
+        items.extend(parse_test_library_arguments(&node.args, context));
+        return items;
 
-        fn parse_test_library_callee<'a>(callee: &'a ExprOrSuper, context: &mut Context<'a>) -> PrintItem {
+        fn parse_test_library_callee<'a>(callee: &'a ExprOrSuper, context: &mut Context<'a>) -> PrintItems {
             match callee {
                 // todo: use box pattern matching once supported in rust stable
                 ExprOrSuper::Expr(expr) => {
                     let expr = &**expr;
                     match expr {
                         Expr::Member(member_expr) => {
-                            let mut items = Vec::new();
-                            items.push(parse_node((&member_expr.obj).into(), context));
-                            items.push(".".into());
-                            items.push(parse_node((&member_expr.prop).into(), context));
-                            items.into()
+                            let mut items = PrintItems::new();
+                            items.extend(parse_node((&member_expr.obj).into(), context));
+                            items.push_str(".");
+                            items.extend(parse_node((&member_expr.prop).into(), context));
+                            items
                         },
                         _=> parse_node(expr.into(), context),
                     }
@@ -1315,37 +1303,30 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintIt
             }
         }
 
-        fn parse_test_library_arguments<'a>(args: &'a Vec<ExprOrSpread>, context: &mut Context<'a>) -> PrintItem {
-            let mut items = Vec::new();
-            items.push("(".into());
-            items.push(parse_node_with_inner_parse((&args[0]).into(), context, |item| {
-                // force everything to go onto one line
-                vec![filter_signals(item), ",".into()].into()
+        fn parse_test_library_arguments<'a>(args: &'a Vec<ExprOrSpread>, context: &mut Context<'a>) -> PrintItems {
+            let mut items = PrintItems::new();
+            items.push_str("(");
+            items.extend(parse_node_with_inner_parse((&args[0]).into(), context, |items| {
+                let mut new_items = filter_signals(items);
+                new_items.push_str(",");
+                new_items
             }));
-            items.push(" ".into());
-            items.push(parse_node((&args[1]).into(), context));
-            items.push(")".into());
+            items.push_str(" ");
+            items.extend(parse_node((&args[1]).into(), context));
+            items.push_str(")");
 
-            return items.into();
+            return items;
         }
 
-        pub fn filter_signals(item: PrintItem) -> PrintItem {
-            let mut items = Vec::new();
-            handle_item(item, &mut items);
-            return items.into();
-
-            fn handle_item(item: PrintItem, items: &mut Vec<PrintItem>) {
+        pub fn filter_signals(old_items: PrintItems) -> PrintItems {
+            let mut items = PrintItems::new();
+            for item in old_items.into_iter() {
                 match item {
-                    PrintItem::Items(print_item_items) => {
-                        for item in print_item_items.into_iter() {
-                            handle_item(item, items);
-                        }
-                    },
-                    PrintItem::Condition(condition) => items.push(PrintItem::Condition(condition)),
-                    PrintItem::Info(info) => items.push(PrintItem::Info(info)),
-                    _ => {},
+                    PrintItem::String(_) | PrintItem::Condition(_) | PrintItem::Info(_) => items.push(item),
+                    PrintItem::Signal(_) => {},
                 }
             }
+            return items;
         }
     }
 
@@ -1394,7 +1375,7 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintIt
     }
 }
 
-fn parse_class_expr<'a>(node: &'a ClassExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_class_expr<'a>(node: &'a ClassExpr, context: &mut Context<'a>) -> PrintItems {
     return parse_class_decl_or_expr(ClassDeclOrExpr {
         span: node.class.span,
         decorators: &node.class.decorators,
@@ -1411,7 +1392,7 @@ fn parse_class_expr<'a>(node: &'a ClassExpr, context: &mut Context<'a>) -> Print
     }, context);
 }
 
-fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> PrintItems {
     let operator_token = context.token_finder.get_first_operator_after(&node.test, "?").unwrap();
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&node.test, &node.cons, context)
         || node_helpers::get_use_new_lines_for_nodes(&node.cons, &node.alt, context);
@@ -1419,63 +1400,61 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
     let start_info = Info::new("startConditionalExpression");
     let before_alternate_info = Info::new("beforeAlternateInfo");
     let end_info = Info::new("endConditionalExpression");
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push(start_info.clone().into());
-    items.push(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.test).into(), context, {
-        move |item| {
+    items.push_info(start_info.clone());
+    items.extend(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.test).into(), context, {
+        move |mut items| {
             if operator_position == OperatorPosition::SameLine {
-                vec![item, " ?".into()].into()
-            } else {
-                item
+                items.push_str(" ?");
             }
+            items
         }
     })));
 
     // force re-evaluation of all the conditions below once the end info has been reached
-    items.push(conditions::force_reevaluation_once_resolved(context.end_statement_or_member_infos.peek().unwrap_or(&end_info).clone()).into());
+    items.push_condition(conditions::force_reevaluation_once_resolved(context.end_statement_or_member_infos.peek().unwrap_or(&end_info).clone()));
 
     if use_new_lines {
-        items.push(PrintItem::NewLine);
+        items.push_signal(Signal::NewLine);
     } else {
-        items.push(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info.clone(), Some(before_alternate_info.clone())).into());
+        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info.clone(), Some(before_alternate_info.clone())));
     }
 
-    items.push(conditions::indent_if_start_of_line({
-        let mut items = Vec::new();
+    items.push_condition(conditions::indent_if_start_of_line({
+        let mut items = PrintItems::new();
         if operator_position == OperatorPosition::NextLine {
-            items.push("? ".into());
+            items.push_str("? ");
         }
-        items.push(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.cons).into(), context, {
-            move |item| {
+        items.extend(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.cons).into(), context, {
+            move |mut items| {
                 if operator_position == OperatorPosition::SameLine {
-                    vec![item, " :".into()].into()
-                } else {
-                    item
+                    items.push_str(" :");
                 }
+                items
             }
         })));
-        items.into()
-    }).into());
+        items
+    }));
 
     if use_new_lines {
-        items.push(PrintItem::NewLine);
+        items.push_signal(Signal::NewLine);
     } else {
-        items.push(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(before_alternate_info.clone())).into());
+        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(before_alternate_info.clone())));
     }
 
-    items.push(conditions::indent_if_start_of_line({
-        let mut items = Vec::new();
+    items.push_condition(conditions::indent_if_start_of_line({
+        let mut items = PrintItems::new();
         if operator_position == OperatorPosition::NextLine {
-            items.push(": ".into());
+            items.push_str(": ");
         }
-        items.push(before_alternate_info.into());
-        items.push(parser_helpers::new_line_group(parse_node((&node.alt).into(), context)));
-        items.push(end_info.into());
-        items.into()
-    }).into());
+        items.push_info(before_alternate_info);
+        items.extend(parser_helpers::new_line_group(parse_node((&node.alt).into(), context)));
+        items.push_info(end_info);
+        items
+    }));
 
-    return items.into();
+    return items;
 
     fn get_operator_position(node: &CondExpr, operator_token: &TokenAndSpan, context: &mut Context) -> OperatorPosition {
         match context.config.conditional_expression_operator_position {
@@ -1492,23 +1471,23 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
     }
 }
 
-fn parse_expr_or_spread<'a>(node: &'a ExprOrSpread, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    if node.spread.is_some() { items.push("...".into()); }
-    items.push(parse_node((&node.expr).into(), context));
-    items.into()
+fn parse_expr_or_spread<'a>(node: &'a ExprOrSpread, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    if node.spread.is_some() { items.push_str("..."); }
+    items.extend(parse_node((&node.expr).into(), context));
+    items
 }
 
-fn parse_expr_with_type_args<'a>(node: &'a TsExprWithTypeArgs, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.expr).into(), context));
+fn parse_expr_with_type_args<'a>(node: &'a TsExprWithTypeArgs, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.expr).into(), context));
     if let Some(type_args) = &node.type_args {
-        items.push(parse_node(type_args.into(), context));
+        items.extend(parse_node(type_args.into(), context));
     }
-    return items.into();
+    return items;
 }
 
-fn parse_fn_expr<'a>(node: &'a FnExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_fn_expr<'a>(node: &'a FnExpr, context: &mut Context<'a>) -> PrintItems {
     parse_function_decl_or_expr(FunctionDeclOrExprNode {
         is_func_decl: false,
         ident: node.ident.as_ref().clone(),
@@ -1517,7 +1496,7 @@ fn parse_fn_expr<'a>(node: &'a FnExpr, context: &mut Context<'a>) -> PrintItem {
     }, context)
 }
 
-fn parse_getter_prop<'a>(node: &'a GetterProp, context: &mut Context<'a>) -> PrintItem {
+fn parse_getter_prop<'a>(node: &'a GetterProp, context: &mut Context<'a>) -> PrintItems {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: None,
         accessibility: None,
@@ -1535,14 +1514,14 @@ fn parse_getter_prop<'a>(node: &'a GetterProp, context: &mut Context<'a>) -> Pri
     }, context);
 }
 
-fn parse_key_value_prop<'a>(node: &'a KeyValueProp, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.key).into(), context));
-    items.push(parse_node_with_preceeding_colon(Some((&node.value).into()), context));
-    return items.into();
+fn parse_key_value_prop<'a>(node: &'a KeyValueProp, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.key).into(), context));
+    items.extend(parse_node_with_preceeding_colon(Some((&node.value).into()), context));
+    return items;
 }
 
-fn parse_member_expr<'a>(node: &'a MemberExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_member_expr<'a>(node: &'a MemberExpr, context: &mut Context<'a>) -> PrintItems {
     return parse_for_member_like_expr(MemberLikeExpr {
         left_node: (&node.obj).into(),
         right_node: (&node.prop).into(),
@@ -1550,7 +1529,7 @@ fn parse_member_expr<'a>(node: &'a MemberExpr, context: &mut Context<'a>) -> Pri
     }, context);
 }
 
-fn parse_meta_prop_expr<'a>(node: &'a MetaPropExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_meta_prop_expr<'a>(node: &'a MetaPropExpr, context: &mut Context<'a>) -> PrintItems {
     return parse_for_member_like_expr(MemberLikeExpr {
         left_node: (&node.meta).into(),
         right_node: (&node.prop).into(),
@@ -1558,31 +1537,31 @@ fn parse_meta_prop_expr<'a>(node: &'a MetaPropExpr, context: &mut Context<'a>) -
     }, context);
 }
 
-fn parse_new_expr<'a>(node: &'a NewExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("new ".into());
-    items.push(parse_node((&node.callee).into(), context));
-    if let Some(type_args) = &node.type_args { items.push(parse_node(type_args.into(), context)); }
+fn parse_new_expr<'a>(node: &'a NewExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("new ");
+    items.extend(parse_node((&node.callee).into(), context));
+    if let Some(type_args) = &node.type_args { items.extend(parse_node(type_args.into(), context)); }
     let args = match node.args.as_ref() {
         Some(args) => args.iter().map(|node| node.into()).collect(),
         None => Vec::new(),
     };
-    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: args,
         force_multi_line_when_multiple_lines: context.config.new_expression_force_multi_line_arguments,
         custom_close_paren: None,
     }, context));
-    return items.into();
+    return items;
 }
 
-fn parse_non_null_expr<'a>(node: &'a TsNonNullExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.expr).into(), context));
-    items.push("!".into());
-    return items.into();
+fn parse_non_null_expr<'a>(node: &'a TsNonNullExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.expr).into(), context));
+    items.push_str("!");
+    return items;
 }
 
-fn parse_object_lit<'a>(node: &'a ObjectLit, context: &mut Context<'a>) -> PrintItem {
+fn parse_object_lit<'a>(node: &'a ObjectLit, context: &mut Context<'a>) -> PrintItems {
     return parse_object_like_node(ParseObjectLikeNodeOptions {
         node_span: node.span,
         members: node.props.iter().map(|x| x.into()).collect(),
@@ -1590,7 +1569,7 @@ fn parse_object_lit<'a>(node: &'a ObjectLit, context: &mut Context<'a>) -> Print
     }, context);
 }
 
-fn parse_paren_expr<'a>(node: &'a ParenExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_paren_expr<'a>(node: &'a ParenExpr, context: &mut Context<'a>) -> PrintItems {
     return conditions::with_indent_if_start_of_line_indented(parse_node_in_parens(
         (&node.expr).into(),
         |context| parse_node((&node.expr).into(), context),
@@ -1598,11 +1577,11 @@ fn parse_paren_expr<'a>(node: &'a ParenExpr, context: &mut Context<'a>) -> Print
     )).into();
 }
 
-fn parse_sequence_expr<'a>(node: &'a SeqExpr, context: &mut Context<'a>) -> PrintItem {
+fn parse_sequence_expr<'a>(node: &'a SeqExpr, context: &mut Context<'a>) -> PrintItems {
     parse_comma_separated_values(node.exprs.iter().map(|x| x.into()).collect(), |_| { Some(false) }, context)
 }
 
-fn parse_setter_prop<'a>(node: &'a SetterProp, context: &mut Context<'a>) -> PrintItem {
+fn parse_setter_prop<'a>(node: &'a SetterProp, context: &mut Context<'a>) -> PrintItems {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: None,
         accessibility: None,
@@ -1620,53 +1599,53 @@ fn parse_setter_prop<'a>(node: &'a SetterProp, context: &mut Context<'a>) -> Pri
     }, context);
 }
 
-fn parse_spread_element<'a>(node: &'a SpreadElement, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("...".into());
-    items.push(parse_node((&node.expr).into(), context));
-    return items.into();
+fn parse_spread_element<'a>(node: &'a SpreadElement, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("...");
+    items.extend(parse_node((&node.expr).into(), context));
+    return items;
 }
 
-fn parse_tagged_tpl<'a>(node: &'a TaggedTpl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.tag).into(), context));
-    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
-    items.push(PrintItem::SpaceOrNewLine);
-    items.push(conditions::indent_if_start_of_line(parse_template_literal(&node.quasis, &node.exprs.iter().map(|x| &**x).collect(), context)).into());
-    return items.into();
+fn parse_tagged_tpl<'a>(node: &'a TaggedTpl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.tag).into(), context));
+    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
+    items.push_signal(Signal::SpaceOrNewLine);
+    items.push_condition(conditions::indent_if_start_of_line(parse_template_literal(&node.quasis, &node.exprs.iter().map(|x| &**x).collect(), context)));
+    return items;
 }
 
-fn parse_tpl<'a>(node: &'a Tpl, context: &mut Context<'a>) -> PrintItem {
+fn parse_tpl<'a>(node: &'a Tpl, context: &mut Context<'a>) -> PrintItems {
     parse_template_literal(&node.quasis, &node.exprs.iter().map(|x| &**x).collect(), context)
 }
 
-fn parse_tpl_element<'a>(node: &'a TplElement, context: &mut Context<'a>) -> PrintItem {
+fn parse_tpl_element<'a>(node: &'a TplElement, context: &mut Context<'a>) -> PrintItems {
     parse_raw_string(node.text(context).into())
 }
 
-fn parse_template_literal<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>, context: &mut Context<'a>) -> PrintItem {
+fn parse_template_literal<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>, context: &mut Context<'a>) -> PrintItems {
     return parser_helpers::new_line_group({
-        let mut items = Vec::new();
-        items.push("`".into());
-        items.push(PrintItem::StartIgnoringIndent);
+        let mut items = PrintItems::new();
+        items.push_str("`");
+        items.push_signal(Signal::StartIgnoringIndent);
         for node in get_nodes(quasis, exprs) {
             if node.kind() == NodeKind::TplElement {
-                items.push(parse_node(node, context));
+                items.extend(parse_node(node, context));
             } else {
-                items.push("${".into());
-                items.push(PrintItem::FinishIgnoringIndent);
-                items.push(PrintItem::PossibleNewLine);
-                items.push(conditions::single_indent_if_start_of_line().into());
-                items.push(parse_node(node, context));
-                items.push(PrintItem::PossibleNewLine);
-                items.push(conditions::single_indent_if_start_of_line().into());
-                items.push("}".into());
-                items.push(PrintItem::StartIgnoringIndent);
+                items.push_str("${");
+                items.push_signal(Signal::FinishIgnoringIndent);
+                items.push_signal(Signal::PossibleNewLine);
+                items.push_condition(conditions::single_indent_if_start_of_line());
+                items.extend(parse_node(node, context));
+                items.push_signal(Signal::PossibleNewLine);
+                items.push_condition(conditions::single_indent_if_start_of_line());
+                items.push_str("}");
+                items.push_signal(Signal::StartIgnoringIndent);
             }
         }
-        items.push("`".into());
-        items.push(PrintItem::FinishIgnoringIndent);
-        items.into()
+        items.push_str("`");
+        items.push_signal(Signal::FinishIgnoringIndent);
+        items
     });
 
     fn get_nodes<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>) -> Vec<Node<'a>> {
@@ -1707,21 +1686,21 @@ fn parse_template_literal<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>
     }
 }
 
-fn parse_type_assertion<'a>(node: &'a TsTypeAssertion, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("<".into());
-    items.push(parse_node((&node.type_ann).into(), context));
-    items.push(">".into());
-    if context.config.type_assertion_space_before_expression { items.push(" ".into()); }
-    items.push(parse_node((&node.expr).into(), context));
-    items.into()
+fn parse_type_assertion<'a>(node: &'a TsTypeAssertion, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("<");
+    items.extend(parse_node((&node.type_ann).into(), context));
+    items.push_str(">");
+    if context.config.type_assertion_space_before_expression { items.push_str(" "); }
+    items.extend(parse_node((&node.expr).into(), context));
+    items
 }
 
-fn parse_unary_expr<'a>(node: &'a UnaryExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.insert(0, get_operator_text(node.op).into());
-    items.push(parse_node((&node.arg).into(), context));
-    return items.into();
+fn parse_unary_expr<'a>(node: &'a UnaryExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str(get_operator_text(node.op));
+    items.extend(parse_node((&node.arg).into(), context));
+    return items;
 
     fn get_operator_text<'a>(op: UnaryOp) -> &'a str {
         match op {
@@ -1736,16 +1715,17 @@ fn parse_unary_expr<'a>(node: &'a UnaryExpr, context: &mut Context<'a>) -> Print
     }
 }
 
-fn parse_update_expr<'a>(node: &'a UpdateExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.arg).into(), context));
+fn parse_update_expr<'a>(node: &'a UpdateExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let operator_text = get_operator_text(node.op);
     if node.prefix {
-        items.insert(0, operator_text.into());
-    } else {
-        items.push(operator_text.into());
+        items.push_str(operator_text);
     }
-    return items.into();
+    items.extend(parse_node((&node.arg).into(), context));
+    if !node.prefix {
+        items.push_str(operator_text);
+    }
+    return items;
 
     fn get_operator_text<'a>(operator: UpdateOp) -> &'a str {
         match operator {
@@ -1755,81 +1735,81 @@ fn parse_update_expr<'a>(node: &'a UpdateExpr, context: &mut Context<'a>) -> Pri
     }
 }
 
-fn parse_yield_expr<'a>(node: &'a YieldExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("yield".into());
-    if node.delegate { items.push("*".into()); }
+fn parse_yield_expr<'a>(node: &'a YieldExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("yield");
+    if node.delegate { items.push_str("*"); }
     if let Some(arg) = &node.arg {
-        items.push(" ".into());
-        items.push(parse_node(arg.into(), context));
+        items.push_str(" ");
+        items.extend(parse_node(arg.into(), context));
     }
-    items.into()
+    items
 }
 
 /* exports */
 
-fn parse_export_named_specifier<'a>(node: &'a NamedExportSpecifier, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_export_named_specifier<'a>(node: &'a NamedExportSpecifier, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
-    items.push(parse_node((&node.orig).into(), context));
+    items.extend(parse_node((&node.orig).into(), context));
     if let Some(exported) = &node.exported {
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
-            items.push("as ".into());
-            items.push(parse_node(exported.into(), context));
-            items.into()
-        }).into());
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str("as ");
+            items.extend(parse_node(exported.into(), context));
+            items
+        }));
     }
 
-    items.into()
+    items
 }
 
 /* imports */
 
-fn parse_import_named_specifier<'a>(node: &'a ImportSpecific, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_import_named_specifier<'a>(node: &'a ImportSpecific, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
     if let Some(imported) = &node.imported {
-        items.push(parse_node(imported.into(), context));
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
-            items.push("as ".into());
-            items.push(parse_node((&node.local).into(), context));
-            items.into()
-        }).into());
+        items.extend(parse_node(imported.into(), context));
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str("as ");
+            items.extend(parse_node((&node.local).into(), context));
+            items
+        }));
     } else {
-        items.push(parse_node((&node.local).into(), context));
+        items.extend(parse_node((&node.local).into(), context));
     }
 
-    items.into()
+    items
 }
 
-fn parse_import_namespace_specifier<'a>(node: &'a ImportStarAs, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("* as ".into());
-    items.push(parse_node((&node.local).into(), context));
-    return items.into();
+fn parse_import_namespace_specifier<'a>(node: &'a ImportStarAs, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("* as ");
+    items.extend(parse_node((&node.local).into(), context));
+    return items;
 }
 
-fn parse_external_module_ref<'a>(node: &'a TsExternalModuleRef, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("require".into());
+fn parse_external_module_ref<'a>(node: &'a TsExternalModuleRef, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("require");
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&context.token_finder.get_first_open_paren_token_within(&node.span), &node.expr, context);
-    items.push(wrap_in_parens(parse_node((&node.expr).into(), context), use_new_lines));
-    return items.into();
+    items.extend(wrap_in_parens(parse_node((&node.expr).into(), context), use_new_lines));
+    return items;
 }
 
 /* interface / type element */
 
-fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_info = Info::new("startCallSignature");
 
-    items.push(start_info.clone().into());
-    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
-    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.push_info(start_info.clone());
+    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
+    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.call_signature_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -1838,20 +1818,20 @@ fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Co
             type_node_separator: None,
         }, context)),
     }, context));
-    if context.config.call_signature_semi_colon { items.push(";".into()); }
+    if context.config.call_signature_semi_colon { items.push_str(";"); }
 
-    return items.into();
+    return items;
 }
 
-fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_info = Info::new("startConstructSignature");
 
-    items.push(start_info.clone().into());
-    items.push("new".into());
-    if context.config.construct_signature_space_after_new_keyword { items.push(" ".into()); }
-    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
-    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.push_info(start_info.clone());
+    items.push_str("new");
+    if context.config.construct_signature_space_after_new_keyword { items.push_str(" "); }
+    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
+    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.construct_signature_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -1860,27 +1840,27 @@ fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, contex
             type_node_separator: None,
         }, context)),
     }, context));
-    if context.config.construct_signature_semi_colon { items.push(";".into()); }
+    if context.config.construct_signature_semi_colon { items.push_str(";"); }
 
-    return items.into();
+    return items;
 }
 
-fn parse_index_signature<'a>(node: &'a TsIndexSignature, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_index_signature<'a>(node: &'a TsIndexSignature, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
-    if node.readonly { items.push("readonly ".into()); }
+    if node.readonly { items.push_str("readonly "); }
 
     // todo: this should do something similar to the other declarations here (the ones with customCloseParen)
-    items.push("[".into());
-    items.push(parse_node(node.params.iter().next().expect("Expected the index signature to have one parameter.").into(), context));
-    items.push("]".into());
-    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    if context.config.index_signature_semi_colon { items.push(";".into()); }
+    items.push_str("[");
+    items.extend(parse_node(node.params.iter().next().expect("Expected the index signature to have one parameter.").into(), context));
+    items.push_str("]");
+    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    if context.config.index_signature_semi_colon { items.push_str(";"); }
 
-    return items.into();
+    return items;
 }
 
-fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>) -> PrintItem {
+fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>) -> PrintItems {
     let start_header_info = get_parent_info(context);
 
     return parse_membered_body(ParseMemberedBodyOptions {
@@ -1904,18 +1884,18 @@ fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>
     }
 }
 
-fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_info = Info::new("startMethodSignature");
-    items.push(start_info.clone().into());
+    items.push_info(start_info.clone());
 
-    if node.computed { items.push("[".into()); }
-    items.push(parse_node((&node.key).into(), context));
-    if node.computed { items.push("]".into()); }
-    if node.optional { items.push("?".into()); }
-    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
+    if node.computed { items.push_str("["); }
+    items.extend(parse_node((&node.key).into(), context));
+    if node.computed { items.push_str("]"); }
+    if node.optional { items.push_str("?"); }
+    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
 
-    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.method_signature_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -1925,36 +1905,36 @@ fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context
         }, context)),
     }, context));
 
-    if context.config.method_signature_semi_colon { items.push(";".into()); }
+    if context.config.method_signature_semi_colon { items.push_str(";"); }
 
-    return items.into();
+    return items;
 }
 
-fn parse_property_signature<'a>(node: &'a TsPropertySignature, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    if node.readonly { items.push("readonly ".into()); }
-    if node.computed { items.push("[".into()); }
-    items.push(parse_node((&node.key).into(), context));
-    if node.computed { items.push("]".into()); }
-    if node.optional { items.push("?".into()); }
-    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+fn parse_property_signature<'a>(node: &'a TsPropertySignature, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    if node.readonly { items.push_str("readonly "); }
+    if node.computed { items.push_str("["); }
+    items.extend(parse_node((&node.key).into(), context));
+    if node.computed { items.push_str("]"); }
+    if node.optional { items.push_str("?"); }
+    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
 
     if let Some(init) = &node.init {
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
-            items.push("= ".into());
-            items.push(parse_node(init.into(), context));
-            items.into()
-        }).into());
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str("= ");
+            items.extend(parse_node(init.into(), context));
+            items
+        }));
     }
 
-    if context.config.property_signature_semi_colon { items.push(";".into()); }
+    if context.config.property_signature_semi_colon { items.push_str(";"); }
 
-    return items.into();
+    return items;
 }
 
-fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> PrintItem {
+fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> PrintItems {
     return parse_object_like_node(ParseObjectLikeNodeOptions {
         node_span: node.span,
         members: node.members.iter().map(|m| m.into()).collect(),
@@ -1964,35 +1944,35 @@ fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> PrintIt
 
 /* jsx */
 
-fn parse_jsx_attribute<'a>(node: &'a JSXAttr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.name).into(), context));
+fn parse_jsx_attribute<'a>(node: &'a JSXAttr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.name).into(), context));
     if let Some(value) = &node.value {
-        items.push("=".into());
+        items.push_str("=");
         let surround_with_braces = context.token_finder.get_previous_token_if_open_brace(value).is_some();
         let parsed_value = parse_node(value.into(), context);
-        items.push(if surround_with_braces {
+        items.extend(if surround_with_braces {
             parse_as_jsx_expr_container(parsed_value, context)
         } else {
             parsed_value
         });
     }
-    return items.into();
+    return items;
 }
 
-fn parse_jsx_closing_element<'a>(node: &'a JSXClosingElement, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("</".into());
-    items.push(parse_node((&node.name).into(), context));
-    items.push(">".into());
-    return items.into();
+fn parse_jsx_closing_element<'a>(node: &'a JSXClosingElement, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("</");
+    items.extend(parse_node((&node.name).into(), context));
+    items.push_str(">");
+    return items;
 }
 
-fn parse_jsx_closing_fragment<'a>(_: &'a JSXClosingFragment, _: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_closing_fragment<'a>(_: &'a JSXClosingFragment, _: &mut Context<'a>) -> PrintItems {
     "</>".into()
 }
 
-fn parse_jsx_element<'a>(node: &'a JSXElement, context: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_element<'a>(node: &'a JSXElement, context: &mut Context<'a>) -> PrintItems {
     if let Some(closing) = &node.closing {
         parse_jsx_with_opening_and_closing(ParseJsxWithOpeningAndClosingOptions {
             opening_element: (&node.opening).into(),
@@ -2004,11 +1984,11 @@ fn parse_jsx_element<'a>(node: &'a JSXElement, context: &mut Context<'a>) -> Pri
     }
 }
 
-fn parse_jsx_empty_expr<'a>(node: &'a JSXEmptyExpr, context: &mut Context<'a>) -> PrintItem {
-    parse_comment_collection(get_jsx_empty_expr_comments(node, context), None, context).unwrap_or(vec![].into())
+fn parse_jsx_empty_expr<'a>(node: &'a JSXEmptyExpr, context: &mut Context<'a>) -> PrintItems {
+    parse_comment_collection(get_jsx_empty_expr_comments(node, context), None, context)
 }
 
-fn parse_jsx_expr_container<'a>(node: &'a JSXExprContainer, context: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_expr_container<'a>(node: &'a JSXExprContainer, context: &mut Context<'a>) -> PrintItems {
     // Don't send JSX empty expressions to parse_node because it will not handle comments
     // the way they should be specifically handled for empty expressions.
     let expr_items = match &node.expr {
@@ -2019,20 +1999,20 @@ fn parse_jsx_expr_container<'a>(node: &'a JSXExprContainer, context: &mut Contex
     parse_as_jsx_expr_container(expr_items, context)
 }
 
-fn parse_as_jsx_expr_container(parsed_node: PrintItem, context: &mut Context) -> PrintItem {
+fn parse_as_jsx_expr_container(parsed_node: PrintItems, context: &mut Context) -> PrintItems {
     let surround_with_space = context.config.jsx_expression_container_space_surrounding_expression;
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push("{".into());
-    if surround_with_space { items.push(" ".into()); }
-    items.push(parsed_node);
-    if surround_with_space { items.push(" ".into()); }
-    items.push("}".into());
+    items.push_str("{");
+    if surround_with_space { items.push_str(" "); }
+    items.extend(parsed_node);
+    if surround_with_space { items.push_str(" "); }
+    items.push_str("}");
 
-    return items.into();
+    return items;
 }
 
-fn parse_jsx_fragment<'a>(node: &'a JSXFragment, context: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_fragment<'a>(node: &'a JSXFragment, context: &mut Context<'a>) -> PrintItems {
     parse_jsx_with_opening_and_closing(ParseJsxWithOpeningAndClosingOptions {
         opening_element: (&node.opening).into(),
         closing_element: (&node.closing).into(),
@@ -2040,79 +2020,79 @@ fn parse_jsx_fragment<'a>(node: &'a JSXFragment, context: &mut Context<'a>) -> P
     }, context)
 }
 
-fn parse_jsx_member_expr<'a>(node: &'a JSXMemberExpr, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.obj).into(), context));
-    items.push(".".into());
-    items.push(parse_node((&node.prop).into(), context));
-    return items.into();
+fn parse_jsx_member_expr<'a>(node: &'a JSXMemberExpr, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.obj).into(), context));
+    items.push_str(".");
+    items.extend(parse_node((&node.prop).into(), context));
+    return items;
 }
 
-fn parse_jsx_namespaced_name<'a>(node: &'a JSXNamespacedName, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.ns).into(), context));
-    items.push(":".into());
-    items.push(parse_node((&node.name).into(), context));
-    return items.into();
+fn parse_jsx_namespaced_name<'a>(node: &'a JSXNamespacedName, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.ns).into(), context));
+    items.push_str(":");
+    items.extend(parse_node((&node.name).into(), context));
+    return items;
 }
 
-fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Context<'a>) -> PrintItems {
     let is_multi_line = get_is_multi_line(node, context);
     let start_info = Info::new("openingElementStartInfo");
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push(start_info.clone().into());
-    items.push("<".into());
-    items.push(parse_node((&node.name).into(), context));
+    items.push_info(start_info.clone());
+    items.push_str("<");
+    items.extend(parse_node((&node.name).into(), context));
     if let Some(type_args) = &node.type_args {
-        items.push(parse_node(type_args.into(), context));
+        items.extend(parse_node(type_args.into(), context));
     }
-    items.push(parse_attribs(&node.attrs, is_multi_line, context));
+    items.extend(parse_attribs(&node.attrs, is_multi_line, context));
     if node.self_closing {
         if !is_multi_line {
-            items.push(" ".into());
+            items.push_str(" ");
         }
-        items.push("/".into());
+        items.push_str("/");
     } else {
         // todo: move condition to core library
-        items.push(Condition::new("newlineIfHanging", ConditionProperties {
+        items.push_condition(Condition::new("newlineIfHanging", ConditionProperties {
             condition: Box::new(move |condition_context| condition_resolvers::is_hanging(condition_context, &start_info, &None)),
-            true_path: Some(PrintItem::NewLine),
+            true_path: Some(Signal::NewLine.into()),
             false_path: None,
-        }).into());
+        }));
     }
-    items.push(">".into());
+    items.push_str(">");
 
-    return items.into();
+    return items;
 
-    fn parse_attribs<'a>(attribs: &'a Vec<JSXAttrOrSpread>, is_multi_line: bool, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn parse_attribs<'a>(attribs: &'a Vec<JSXAttrOrSpread>, is_multi_line: bool, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
         if attribs.is_empty() {
-            return items.into();
+            return items;
         }
 
         for attrib in attribs {
-            items.push(if is_multi_line {
-                PrintItem::NewLine
+            items.push_signal(if is_multi_line {
+                Signal::NewLine
             } else {
-                PrintItem::SpaceOrNewLine
+                Signal::SpaceOrNewLine
             });
 
-            items.push(conditions::indent_if_start_of_line({
+            items.push_condition(conditions::indent_if_start_of_line({
                 match attrib {
                     JSXAttrOrSpread::JSXAttr(attr) => parse_node(attr.into(), context),
                     JSXAttrOrSpread::SpreadElement(element) => {
                         parse_as_jsx_expr_container(parse_node(element.into(), context), context)
                     }
                 }
-            }).into());
+            }));
         }
 
         if is_multi_line {
-            items.push(PrintItem::NewLine);
+            items.push_signal(Signal::NewLine);
         }
 
-        return items.into();
+        return items;
     }
 
     fn get_is_multi_line(node: &JSXOpeningElement, context: &mut Context) -> bool {
@@ -2124,74 +2104,74 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
     }
 }
 
-fn parse_jsx_opening_fragment<'a>(_: &'a JSXOpeningFragment, _: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_opening_fragment<'a>(_: &'a JSXOpeningFragment, _: &mut Context<'a>) -> PrintItems {
     "<>".into()
 }
 
-fn parse_jsx_spread_child<'a>(node: &'a JSXSpreadChild, context: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_spread_child<'a>(node: &'a JSXSpreadChild, context: &mut Context<'a>) -> PrintItems {
     parse_as_jsx_expr_container({
-        let mut items = Vec::new();
-        items.push("...".into());
-        items.push(parse_node((&node.expr).into(), context));
-        items.into()
+        let mut items = PrintItems::new();
+        items.push_str("...");
+        items.extend(parse_node((&node.expr).into(), context));
+        items
     }, context)
 }
 
-fn parse_jsx_text<'a>(node: &'a JSXText, context: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_text<'a>(node: &'a JSXText, context: &mut Context<'a>) -> PrintItems {
     let lines = node.text(context).trim().lines().map(|line| line.trim_end());
     let mut past_line: Option<&str> = None;
     let mut past_past_line: Option<&str> = None;
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
     for line in lines {
         if let Some(past_line) = past_line {
             if !line.is_empty() || past_past_line.is_none() {
-                items.push(PrintItem::NewLine);
+                items.push_signal(Signal::NewLine);
             } else if let Some(past_past_line) = past_past_line {
                 if past_line.is_empty() && !past_past_line.is_empty() {
-                    items.push(PrintItem::NewLine);
+                    items.push_signal(Signal::NewLine);
                 }
             }
         }
 
         if !line.is_empty() {
-            items.push(line.into());
+            items.push_str(line);
         }
 
         past_past_line = std::mem::replace(&mut past_line, Some(line));
     }
 
-    return items.into();
+    return items;
 }
 
 /* literals */
 
-fn parse_big_int_literal<'a>(node: &'a BigInt, context: &mut Context<'a>) -> PrintItem {
+fn parse_big_int_literal<'a>(node: &'a BigInt, context: &mut Context<'a>) -> PrintItems {
     node.text(context).into()
 }
 
-fn parse_bool_literal(node: &Bool) -> PrintItem {
+fn parse_bool_literal(node: &Bool) -> PrintItems {
     match node.value {
         true => "true",
         false => "false",
     }.into()
 }
 
-fn parse_num_literal<'a>(node: &'a Number, context: &mut Context<'a>) -> PrintItem {
+fn parse_num_literal<'a>(node: &'a Number, context: &mut Context<'a>) -> PrintItems {
     node.text(context).into()
 }
 
-fn parse_reg_exp_literal(node: &Regex, _: &mut Context) -> PrintItem {
+fn parse_reg_exp_literal(node: &Regex, _: &mut Context) -> PrintItems {
     // the exp and flags should not be nodes so just ignore that (swc issue #511)
-    let mut items = Vec::new();
-    items.push("/".into());
-    items.push((&node.exp as &str).into());
-    items.push("/".into());
-    items.push((&node.flags as &str).into());
-    items.into()
+    let mut items = PrintItems::new();
+    items.push_str("/");
+    items.push_str(&node.exp as &str);
+    items.push_str("/");
+    items.push_str(&node.flags as &str);
+    items
 }
 
-fn parse_string_literal<'a>(node: &'a Str, context: &mut Context<'a>) -> PrintItem {
+fn parse_string_literal<'a>(node: &'a Str, context: &mut Context<'a>) -> PrintItems {
     return parse_raw_string(&get_string_literal_text(get_string_value(&node, context), context));
 
     fn get_string_literal_text(string_value: String, context: &mut Context) -> String {
@@ -2215,19 +2195,19 @@ fn parse_string_literal<'a>(node: &'a Str, context: &mut Context<'a>) -> PrintIt
 
 /* module */
 
-fn parse_module<'a>(node: &'a Module, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_module<'a>(node: &'a Module, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if let Some(shebang) = &node.shebang {
-        items.push("#!".into());
-        items.push((&shebang as &str).into());
-        items.push(PrintItem::NewLine);
+        items.push_str("#!");
+        items.push_str(&shebang as &str);
+        items.push_signal(Signal::NewLine);
         if let Some(first_statement) = node.body.first() {
             if node_helpers::has_separating_blank_line(&node.span.lo(), &first_statement, context) {
-                items.push(PrintItem::NewLine);
+                items.push_signal(Signal::NewLine);
             }
         }
     }
-    items.push(parse_statements_or_members(ParseStatementsOrMembersOptions {
+    items.extend(parse_statements_or_members(ParseStatementsOrMembersOptions {
         inner_span: node.span,
         items: node.body.iter().map(|module_item| (module_item.into(), None)).collect(),
         should_use_space: None,
@@ -2235,75 +2215,76 @@ fn parse_module<'a>(node: &'a Module, context: &mut Context<'a>) -> PrintItem {
         should_use_blank_line: |previous, next, context| node_helpers::has_separating_blank_line(previous, next, context),
         trailing_commas: None,
     }, context));
-    return items.into();
+    return items;
 }
 
 /* patterns */
 
-fn parse_array_pat<'a>(node: &'a ArrayPat, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_array_like_nodes(ParseArrayLikeNodesOptions {
+fn parse_array_pat<'a>(node: &'a ArrayPat, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_array_like_nodes(ParseArrayLikeNodesOptions {
         parent_span: node.span,
         elements: node.elems.iter().map(|x| x.as_ref().map(|elem| elem.into())).collect(),
         trailing_commas: context.config.array_pattern_trailing_commas,
     }, context));
-    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    items.into()
+    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items
 }
 
-fn parse_assign_pat<'a>(node: &'a AssignPat, context: &mut Context<'a>) -> PrintItem {
+fn parse_assign_pat<'a>(node: &'a AssignPat, context: &mut Context<'a>) -> PrintItems {
     parser_helpers::new_line_group({
-        let mut items = Vec::new();
-        items.push(parse_node((&node.left).into(), context));
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = vec!["= ".into()];
-            items.push(parse_node((&node.right).into(), context));
-            items.into()
-        }).into());
-        items.into()
+        let mut items = PrintItems::new();
+        items.extend(parse_node((&node.left).into(), context));
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str("= ");
+            items.extend(parse_node((&node.right).into(), context));
+            items
+        }));
+        items
     })
 }
 
-fn parse_assign_pat_prop<'a>(node: &'a AssignPatProp, context: &mut Context<'a>) -> PrintItem {
+fn parse_assign_pat_prop<'a>(node: &'a AssignPatProp, context: &mut Context<'a>) -> PrintItems {
     return parser_helpers::new_line_group({
-        let mut items = Vec::new();
-        items.push(parse_node((&node.key).into(), context));
+        let mut items = PrintItems::new();
+        items.extend(parse_node((&node.key).into(), context));
         if let Some(value) = &node.value {
-            items.push(PrintItem::SpaceOrNewLine);
-            items.push(conditions::indent_if_start_of_line({
-                let mut items = Vec::new();
-                items.push("= ".into());
-                items.push(parse_node(value.into(), context));
-                items.into()
-            }).into());
+            items.push_signal(Signal::SpaceOrNewLine);
+            items.push_condition(conditions::indent_if_start_of_line({
+                let mut items = PrintItems::new();
+                items.push_str("= ");
+                items.extend(parse_node(value.into(), context));
+                items
+            }));
         }
-        items.into()
+        items
     });
 }
 
-fn parse_rest_pat<'a>(node: &'a RestPat, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("...".into());
-    items.push(parse_node((&node.arg).into(), context));
-    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    items.into()
+fn parse_rest_pat<'a>(node: &'a RestPat, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("...");
+    items.extend(parse_node((&node.arg).into(), context));
+    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items
 }
 
-fn parse_object_pat<'a>(node: &'a ObjectPat, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_object_like_node(ParseObjectLikeNodeOptions {
+fn parse_object_pat<'a>(node: &'a ObjectPat, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_object_like_node(ParseObjectLikeNodeOptions {
         node_span: node.span,
         members: node.props.iter().map(|x| x.into()).collect(),
         trailing_commas: Some(TrailingCommas::Never),
     }, context));
-    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    return items.into();
+    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    return items;
 }
 
 /* properties */
 
-fn parse_method_prop<'a>(node: &'a MethodProp, context: &mut Context<'a>) -> PrintItem {
+fn parse_method_prop<'a>(node: &'a MethodProp, context: &mut Context<'a>) -> PrintItems {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: None,
         accessibility: None,
@@ -2354,35 +2335,35 @@ impl From<MethodKind> for ClassOrObjectMethodKind {
     }
 }
 
-fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if let Some(decorators) = node.decorators.as_ref() {
-        items.push(parse_decorators(decorators, false, context));
+        items.extend(parse_decorators(decorators, false, context));
     }
 
     let start_header_info = Info::new("methodStartHeaderInfo");
-    items.push(start_header_info.clone().into());
+    items.push_info(start_header_info.clone());
 
     if let Some(accessibility) = node.accessibility {
-        items.push(format!("{} ", accessibility_to_str(&accessibility)).into());
+        items.push_str(&format!("{} ", accessibility_to_str(&accessibility)));
     }
-    if node.is_static { items.push("static ".into()); }
-    if node.is_async { items.push("async ".into()); }
-    if node.is_abstract { items.push("abstract ".into()); }
+    if node.is_static { items.push_str("static "); }
+    if node.is_async { items.push_str("async "); }
+    if node.is_abstract { items.push_str("abstract "); }
 
     match node.kind {
-        ClassOrObjectMethodKind::Getter => items.push("get ".into()),
-        ClassOrObjectMethodKind::Setter => items.push("set ".into()),
+        ClassOrObjectMethodKind::Getter => items.push_str("get "),
+        ClassOrObjectMethodKind::Setter => items.push_str("set "),
         ClassOrObjectMethodKind::Method | ClassOrObjectMethodKind::Constructor => {},
     }
 
-    if node.is_generator { items.push("*".into()); }
-    items.push(parse_node(node.key, context));
-    if node.is_optional { items.push("?".into()); }
-    if let Some(type_params) = node.type_params { items.push(parse_node(type_params, context)); }
-    if get_use_space_before_parens(&node.kind, context) { items.push(" ".into()) }
+    if node.is_generator { items.push_str("*"); }
+    items.extend(parse_node(node.key, context));
+    if node.is_optional { items.push_str("?"); }
+    if let Some(type_params) = node.type_params { items.extend(parse_node(type_params, context)); }
+    if get_use_space_before_parens(&node.kind, context) { items.push_str(" ") }
 
-    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.into_iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: get_force_multi_line_parameters(&node.kind, context),
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -2394,17 +2375,17 @@ fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut
 
     if let Some(body) = node.body {
         let brace_position = get_brace_position(&node.kind, context);
-        items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+        items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
             brace_position: brace_position,
             open_brace_token: context.token_finder.get_first_open_brace_token_within(&body),
             start_header_info: Some(start_header_info),
         }, context));
-        items.push(parse_node(body, context));
+        items.extend(parse_node(body, context));
     } else if get_use_semi_colon(&node.kind, context) {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    return items.into();
+    return items;
 
     fn get_force_multi_line_parameters(kind: &ClassOrObjectMethodKind, context: &mut Context) -> bool {
         match kind {
@@ -2453,201 +2434,194 @@ fn accessibility_to_str(accessibility: &Accessibility) -> &str {
 
 /* statements */
 
-fn parse_block_stmt<'a>(node: &'a BlockStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_block_stmt<'a>(node: &'a BlockStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_statements_info = Info::new("startStatementsInfo");
     let end_statements_info = Info::new("endStatementsInfo");
     let open_brace_token = context.token_finder.get_first_open_brace_token_within(&node);
 
-    items.push("{".into());
-
-    if let Some(parsed_comments) = parse_trailing_comments(&open_brace_token, context) {
-        items.push(parsed_comments);
-    }
+    items.push_str("{");
+    items.extend(parse_trailing_comments(&open_brace_token, context));
 
     // Allow: const t = () => {}; and const t = function() {};
     let is_arrow_or_fn_expr = match context.parent().kind() { NodeKind::ArrowExpr | NodeKind::FnExpr => true, _ => false };
     if is_arrow_or_fn_expr && node.start_line(context) == node.end_line(context) && node.stmts.is_empty() && !node.leading_comments(context).peekable().peek().is_some() {
-        items.push("}".into());
-        return items.into();
+        items.push_str("}");
+        return items;
     }
 
-    if let Some(parsed_comments) = parse_first_line_trailing_comments(&node, node.stmts.get(0).map(|x| x as &dyn Spanned), context) {
-        items.push(parsed_comments);
-    }
-    items.push(PrintItem::NewLine);
-    items.push(start_statements_info.clone().into());
-    items.push(parser_helpers::with_indent(
+    items.extend(parse_first_line_trailing_comments(&node, node.stmts.get(0).map(|x| x as &dyn Spanned), context));
+    items.push_signal(Signal::NewLine);
+    items.push_info(start_statements_info.clone());
+    items.extend(parser_helpers::with_indent(
         parse_statements(node.get_inner_span(context), node.stmts.iter().map(|stmt| stmt.into()).collect(), context)
     ));
-    items.push(end_statements_info.clone().into());
-    items.push(Condition::new("endStatementsNewLine", ConditionProperties {
+    items.push_info(end_statements_info.clone());
+    items.push_condition(Condition::new("endStatementsNewLine", ConditionProperties {
         condition: Box::new(move |context| {
             condition_resolvers::are_infos_equal(context, &start_statements_info, &end_statements_info)
         }),
         true_path: None,
-        false_path: Some(PrintItem::NewLine),
-    }).into());
-    items.push("}".into());
+        false_path: Some(Signal::NewLine.into()),
+    }));
+    items.push_str("}");
 
-    return items.into();
+    return items;
 }
 
-fn parse_break_stmt<'a>(node: &'a BreakStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_break_stmt<'a>(node: &'a BreakStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
-    items.push("break".into());
+    items.push_str("break");
     if let Some(label) = &node.label {
-        items.push(" ".into());
-        items.push(parse_node(label.into(), context));
+        items.push_str(" ");
+        items.extend(parse_node(label.into(), context));
     }
     if context.config.break_statement_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    items.into()
+    items
 }
 
-fn parse_continue_stmt<'a>(node: &'a ContinueStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_continue_stmt<'a>(node: &'a ContinueStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
-    items.push("continue".into());
+    items.push_str("continue");
     if let Some(label) = &node.label {
-        items.push(" ".into());
-        items.push(parse_node(label.into(), context));
+        items.push_str(" ");
+        items.extend(parse_node(label.into(), context));
     }
     if context.config.continue_statement_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    items.into()
+    items
 }
 
-fn parse_debugger_stmt<'a>(_: &'a DebuggerStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_debugger_stmt<'a>(_: &'a DebuggerStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
-    items.push("debugger".into());
+    items.push_str("debugger");
     if context.config.debugger_statement_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    items.into()
+    items
 }
 
-fn parse_do_while_stmt<'a>(node: &'a DoWhileStmt, context: &mut Context<'a>) -> PrintItem {
+fn parse_do_while_stmt<'a>(node: &'a DoWhileStmt, context: &mut Context<'a>) -> PrintItems {
     // the braces are technically optional on do while statements
-    let mut items = Vec::new();
-    items.push("do".into());
-    items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+    let mut items = PrintItems::new();
+    items.push_str("do");
+    items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
         brace_position: context.config.do_while_statement_brace_position,
         open_brace_token: if let Stmt::Block(_) = &*node.body { context.token_finder.get_first_open_brace_token_within(&node) } else { None },
         start_header_info: None,
     }, context));
-    items.push(parse_node((&node.body).into(), context));
-    items.push(" while".into());
+    items.extend(parse_node((&node.body).into(), context));
+    items.push_str(" while");
     if context.config.do_while_statement_space_after_while_keyword {
-        items.push(" ".into());
+        items.push_str(" ");
     }
-    items.push(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
+    items.extend(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
     if context.config.do_while_statement_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
-    return items.into();
+    return items;
 }
 
-fn parse_export_all<'a>(node: &'a ExportAll, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("export * from ".into());
-    items.push(parse_node((&node.src).into(), context));
+fn parse_export_all<'a>(node: &'a ExportAll, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("export * from ");
+    items.extend(parse_node((&node.src).into(), context));
 
     if context.config.export_all_declaration_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    items.into()
+    items
 }
 
-fn parse_empty_stmt(_: &EmptyStmt, _: &mut Context) -> PrintItem {
+fn parse_empty_stmt(_: &EmptyStmt, _: &mut Context) -> PrintItems {
     ";".into()
 }
 
-fn parse_export_assignment<'a>(node: &'a TsExportAssignment, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_export_assignment<'a>(node: &'a TsExportAssignment, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
-    items.push("export = ".into());
-    items.push(parse_node((&node.expr).into(), context));
+    items.push_str("export = ");
+    items.extend(parse_node((&node.expr).into(), context));
     if context.config.export_assignment_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    items.into()
+    items
 }
 
-fn parse_namespace_export<'a>(node: &'a TsNamespaceExportDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("export as namespace ".into());
-    items.push(parse_node((&node.id).into(), context));
+fn parse_namespace_export<'a>(node: &'a TsNamespaceExportDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("export as namespace ");
+    items.extend(parse_node((&node.id).into(), context));
 
     if context.config.namespace_export_declaration_semi_colon {
-        items.push(";".into());
+        items.push_str(";");
     }
 
-    items.into()
+    items
 }
 
-fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItem {
+fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItems {
     if context.config.expression_statement_semi_colon {
         return parse_inner(&stmt, context);
     } else {
         return parse_for_prefix_semi_colon_insertion(&stmt, context);
     }
 
-    fn parse_inner<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
-        items.push(parse_node((&stmt.expr).into(), context));
+    fn parse_inner<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.extend(parse_node((&stmt.expr).into(), context));
         if context.config.expression_statement_semi_colon {
-            items.push(";".into());
+            items.push_str(";");
         }
-        return items.into();
+        return items;
     }
 
-    fn parse_for_prefix_semi_colon_insertion<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItem {
+    fn parse_for_prefix_semi_colon_insertion<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItems {
         let parsed_node = parse_inner(&stmt, context);
-        return if should_add_semi_colon(&parsed_node).unwrap_or(false) {
-            vec![";".into(), parsed_node].into()
+        // todo: investigate removing this clone
+        return if should_add_semi_colon(parsed_node.clone()).unwrap_or(false) {
+            let mut items = PrintItems::new();
+            items.push_str(";");
+            items.extend(parsed_node);
+            items
         } else {
             parsed_node
         };
 
-        fn should_add_semi_colon(item: &PrintItem) -> Option<bool> {
-            match item {
-                PrintItem::Items(items) => {
-                    for item in items.iter() {
-                        if let Some(result) = should_add_semi_colon(item) {
-                            return result.into();
+        fn should_add_semi_colon(items: PrintItems) -> Option<bool> {
+            // todo: items.iter()?
+            for item in items.into_iter() {
+                match item {
+                    PrintItem::String(value) => {
+                        if let Some(c) = value.chars().next() {
+                            return utils::is_prefix_semi_colon_insertion_char(c).into();
                         }
-                    }
-                },
-                PrintItem::String(value) => {
-                    if let Some(c) = value.chars().next() {
-                        return utils::is_prefix_semi_colon_insertion_char(c).into();
-                    }
-                },
-                PrintItem::Condition(condition) => {
-                    // It's an assumption here that th etrue and false paths of the
-                    // condition will both contain the same text to look for.
-                    if let Some(true_path) = &condition.true_path {
-                        if let Some(result) = should_add_semi_colon(true_path) {
-                            return result.into();
+                    },
+                    PrintItem::Condition(condition) => {
+                        // It's an assumption here that the true and false paths of the
+                        // condition will both contain the same text to look for. This is probably not robust
+                        // and perhaps instead there should be a way to do something like "get the next character" in
+                        // the printer.
+                        if let Some(result) = should_add_semi_colon(condition.get_true_items()) {
+                            return Some(result);
                         }
-                    }
-                    if let Some(false_path) = &condition.false_path {
-                        if let Some(result) = should_add_semi_colon(false_path) {
-                            return result.into();
+                        if let Some(result) = should_add_semi_colon(condition.get_false_items()) {
+                            return Some(result);
                         }
-                    }
-                },
-                _ => { /* do nothing */ },
+                    },
+                    _ => { /* do nothing */ },
+                }
             }
 
             None
@@ -2655,50 +2629,50 @@ fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintIt
     }
 }
 
-fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> PrintItem {
+fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> PrintItems {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
-    let mut items = Vec::new();
-    items.push(start_header_info.clone().into());
-    items.push("for".into());
+    let mut items = PrintItems::new();
+    items.push_info(start_header_info.clone());
+    items.push_str("for");
     if context.config.for_statement_space_after_for_keyword {
-        items.push(" ".into());
+        items.push_str(" ");
     }
-    items.push(parse_node_in_parens({
+    items.extend(parse_node_in_parens({
         if let Some(init) = &node.init {
             init.into()
         } else {
             context.token_finder.get_first_semi_colon_within(&node).expect("Expected to find a semi-colon within the for stmt.").into()
         }
     }, |context| {
-        let mut items = Vec::new();
-        let separator_after_semi_colons = if context.config.for_statement_space_after_semi_colons { PrintItem::SpaceOrNewLine } else { PrintItem::PossibleNewLine }.into_rc();
-        items.push(parser_helpers::new_line_group({
-            let mut items = Vec::new();
+        let mut items = PrintItems::new();
+        let separator_after_semi_colons = if context.config.for_statement_space_after_semi_colons { Signal::SpaceOrNewLine } else { Signal::PossibleNewLine };
+        items.extend(parser_helpers::new_line_group({
+            let mut items = PrintItems::new();
             if let Some(init) = &node.init {
-                items.push(parse_node(init.into(), context));
+                items.extend(parse_node(init.into(), context));
             }
-            items.push(";".into());
-            items.into()
+            items.push_str(";");
+            items
         }));
-        items.push(separator_after_semi_colons.clone().into());
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
+        items.push_signal(separator_after_semi_colons);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
             if let Some(test) = &node.test {
-                items.push(parse_node(test.into(), context));
+                items.extend(parse_node(test.into(), context));
             }
-            items.push(";".into());
-            items.into()
-        }).into());
-        items.push(separator_after_semi_colons.into());
+            items.push_str(";");
+            items
+        }));
+        items.push_signal(separator_after_semi_colons);
         if let Some(update) = &node.update {
-            items.push(conditions::indent_if_start_of_line(parse_node(update.into(), context)).into());
+            items.push_condition(conditions::indent_if_start_of_line(parse_node(update.into(), context)));
         }
-        items.into()
+        items
     }, context));
-    items.push(end_header_info.clone().into());
+    items.push_info(end_header_info.clone());
 
-    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: context.config.for_statement_use_braces,
@@ -2710,33 +2684,33 @@ fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> PrintItem
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
 
-    return items.into();
+    return items;
 }
 
-fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> PrintItem {
+fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> PrintItems {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
-    let mut items = Vec::new();
-    items.push(start_header_info.clone().into());
-    items.push("for".into());
+    let mut items = PrintItems::new();
+    items.push_info(start_header_info.clone());
+    items.push_str("for");
     if context.config.for_in_statement_space_after_for_keyword {
-        items.push(" ".into());
+        items.push_str(" ");
     }
-    items.push(parse_node_in_parens((&node.left).into(), |context| {
-        let mut items = Vec::new();
-        items.push(parse_node((&node.left).into(), context));
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
-            items.push("in ".into());
-            items.push(parse_node((&node.right).into(), context));
-            items.into()
-        }).into());
-        items.into()
+    items.extend(parse_node_in_parens((&node.left).into(), |context| {
+        let mut items = PrintItems::new();
+        items.extend(parse_node((&node.left).into(), context));
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str("in ");
+            items.extend(parse_node((&node.right).into(), context));
+            items
+        }));
+        items
     }, context));
-    items.push(end_header_info.clone().into());
+    items.push_info(end_header_info.clone());
 
-    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: context.config.for_in_statement_use_braces,
@@ -2748,37 +2722,37 @@ fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> Prin
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
 
-    return items.into();
+    return items;
 }
 
-fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> PrintItem {
+fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> PrintItems {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
-    let mut items = Vec::new();
-    items.push(start_header_info.clone().into());
-    items.push("for".into());
+    let mut items = PrintItems::new();
+    items.push_info(start_header_info.clone());
+    items.push_str("for");
     if context.config.for_of_statement_space_after_for_keyword {
-        items.push(" ".into());
+        items.push_str(" ");
     }
     if let Some(await_token) = &node.await_token {
-        items.push(parse_node(await_token.into(), context));
-        items.push(" ".into());
+        items.extend(parse_node(await_token.into(), context));
+        items.push_str(" ");
     }
-    items.push(parse_node_in_parens((&node.left).into(), |context| {
-        let mut items = Vec::new();
-        items.push(parse_node((&node.left).into(), context));
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
-            items.push("of ".into());
-            items.push(parse_node((&node.right).into(), context));
-            items.into()
-        }).into());
-        items.into()
+    items.extend(parse_node_in_parens((&node.left).into(), |context| {
+        let mut items = PrintItems::new();
+        items.extend(parse_node((&node.left).into(), context));
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str("of ");
+            items.extend(parse_node((&node.right).into(), context));
+            items
+        }));
+        items
     }, context));
-    items.push(end_header_info.clone().into());
+    items.push_info(end_header_info.clone());
 
-    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: context.config.for_of_statement_use_braces,
@@ -2790,23 +2764,23 @@ fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> Prin
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
 
-    return items.into();
+    return items;
 }
 
-fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let cons = &*node.cons;
     let cons_span = cons.span();
     let result = parse_header_with_conditional_brace_body(ParseHeaderWithConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: cons.into(),
         parsed_header: {
-            let mut items = Vec::new();
-            items.push("if".into());
-            if context.config.if_statement_space_after_if_keyword { items.push(" ".into()); }
+            let mut items = PrintItems::new();
+            items.push_str("if");
+            if context.config.if_statement_space_after_if_keyword { items.push_str(" "); }
             let test = &*node.test;
-            items.push(parse_node_in_parens(test.into(), |context| parse_node(test.into(), context), context));
-            items.into()
+            items.extend(parse_node_in_parens(test.into(), |context| parse_node(test.into(), context), context));
+            items
         },
         use_braces: context.config.if_statement_use_braces,
         brace_position: context.config.if_statement_brace_position,
@@ -2814,7 +2788,7 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> PrintItem {
         requires_braces_condition: context.take_if_stmt_last_brace_condition(),
     }, context);
 
-    items.push(result.parsed_node);
+    items.extend(result.parsed_node);
 
     if let Some(alt) = &node.alt {
         if let Stmt::If(alt_alt) = &**alt {
@@ -2823,26 +2797,22 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> PrintItem {
             }
         }
 
-        items.push(parse_control_flow_separator(context.config.if_statement_next_control_flow_position, &cons_span, "else", context));
+        items.extend(parse_control_flow_separator(context.config.if_statement_next_control_flow_position, &cons_span, "else", context));
 
         // parse the leading comments before the else keyword
         let else_keyword = context.token_finder.get_first_else_keyword_within(&Span::new(cons_span.hi(), alt.lo(), Default::default())).expect("Expected to find an else keyword.");
-        if let Some(parsed_comments) = parse_leading_comments(else_keyword, context) {
-            items.push(parsed_comments);
-        }
-        if let Some(parsed_comments) = parse_leading_comments(&alt, context) {
-            items.push(parsed_comments);
-        }
+        items.extend(parse_leading_comments(else_keyword, context));
+        items.extend(parse_leading_comments(&alt, context));
 
         let start_else_header_info = Info::new("startElseHeader");
-        items.push(start_else_header_info.clone().into());
-        items.push("else".into());
+        items.push_info(start_else_header_info.clone());
+        items.push_str("else");
 
         if let Stmt::If(alt) = &**alt {
-            items.push(" ".into());
-            items.push(parse_node(alt.into(), context));
+            items.push_str(" ");
+            items.extend(parse_node(alt.into(), context));
         } else {
-            items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+            items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
                 parent: &node.span,
                 body_node: alt.into(),
                 use_braces: context.config.if_statement_use_braces,
@@ -2856,44 +2826,44 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> PrintItem {
         }
     }
 
-    return items.into();
+    return items;
 }
 
-fn parse_labeled_stmt<'a>(node: &'a LabeledStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.label).into(), context));
-    items.push(":".into());
+fn parse_labeled_stmt<'a>(node: &'a LabeledStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.label).into(), context));
+    items.push_str(":");
 
     // not bothering to make this configurable, because who uses labeled statements?
-    items.push(if node.body.kind() == NodeKind::BlockStmt {
-        " ".into()
+    if node.body.kind() == NodeKind::BlockStmt {
+        items.push_str(" ");
     } else {
-        PrintItem::NewLine
-    });
-
-    items.push(parse_node((&node.body).into(), context));
-
-    return items.into();
-}
-
-fn parse_return_stmt<'a>(node: &'a ReturnStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("return".into());
-    if let Some(arg) = &node.arg {
-        items.push(" ".into());
-        items.push(parse_node(arg.into(), context));
+        items.push_signal(Signal::NewLine);
     }
-    if context.config.return_statement_semi_colon { items.push(";".into()); }
-    return items.into();
+
+    items.extend(parse_node((&node.body).into(), context));
+
+    return items;
 }
 
-fn parse_switch_stmt<'a>(node: &'a SwitchStmt, context: &mut Context<'a>) -> PrintItem {
+fn parse_return_stmt<'a>(node: &'a ReturnStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("return");
+    if let Some(arg) = &node.arg {
+        items.push_str(" ");
+        items.extend(parse_node(arg.into(), context));
+    }
+    if context.config.return_statement_semi_colon { items.push_str(";"); }
+    return items;
+}
+
+fn parse_switch_stmt<'a>(node: &'a SwitchStmt, context: &mut Context<'a>) -> PrintItems {
     let start_header_info = Info::new("startHeader");
-    let mut items = Vec::new();
-    items.push(start_header_info.clone().into());
-    items.push("switch ".into());
-    items.push(parse_node_in_parens((&node.discriminant).into(), |context| parse_node((&node.discriminant).into(), context), context));
-    items.push(parse_membered_body(ParseMemberedBodyOptions {
+    let mut items = PrintItems::new();
+    items.push_info(start_header_info.clone());
+    items.push_str("switch ");
+    items.extend(parse_node_in_parens((&node.discriminant).into(), |context| parse_node((&node.discriminant).into(), context), context));
+    items.extend(parse_membered_body(ParseMemberedBodyOptions {
         span: node.span,
         members: node.cases.iter().map(|x| x.into()).collect(),
         start_header_info: Some(start_header_info),
@@ -2901,44 +2871,42 @@ fn parse_switch_stmt<'a>(node: &'a SwitchStmt, context: &mut Context<'a>) -> Pri
         should_use_blank_line: |_, _, _| false,
         trailing_commas: None,
     }, context));
-    return items.into();
+    return items;
 }
 
-fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> PrintItem {
+fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> PrintItems {
     let block_stmt_body = get_block_stmt_body(&node);
     let start_header_info = Info::new("switchCaseStartHeader");
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
     let colon_token = context.token_finder.get_first_colon_token_after(&if let Some(test) = &node.test {
         test.span().hi()
     } else {
         node.span.lo()
     }).expect("Expected to find a colon token.");
 
-    items.push(start_header_info.clone().into());
+    items.push_info(start_header_info.clone());
 
     if let Some(test) = &node.test {
-        items.push("case ".into());
-        items.push(parse_node(test.into(), context));
-        items.push(":".into());
+        items.push_str("case ");
+        items.extend(parse_node(test.into(), context));
+        items.push_str(":");
     } else {
-        items.push("default:".into());
+        items.push_str("default:");
     }
 
-    if let Some(parsed_comments) = parse_first_line_trailing_comments(&node.span, node.cons.get(0).map(|x| x as &dyn Spanned), context) {
-        items.push(parsed_comments);
-    }
+    items.extend(parse_first_line_trailing_comments(&node.span, node.cons.get(0).map(|x| x as &dyn Spanned), context));
     let parsed_trailing_comments = parse_trailing_comments_for_case(node.span, &block_stmt_body, context);
     if !node.cons.is_empty() {
         if let Some(block_stmt_body) = block_stmt_body {
-            items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+            items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
                 brace_position: context.config.switch_case_brace_position,
                 open_brace_token: context.token_finder.get_first_open_brace_token_within(&block_stmt_body),
                 start_header_info: None,
             }, context));
-            items.push(parse_node(node.cons.iter().next().unwrap().into(), context));
+            items.extend(parse_node(node.cons.iter().next().unwrap().into(), context));
         } else {
-            items.push(PrintItem::NewLine);
-            items.push(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
+            items.push_signal(Signal::NewLine);
+            items.extend(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
                 inner_span: Span::new(colon_token.hi(), node.span.hi(), Default::default()),
                 items: node.cons.iter().map(|node| (node.into(), None)).collect(),
                 should_use_space: None,
@@ -2949,9 +2917,9 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Pri
         }
     }
 
-    items.push(parsed_trailing_comments);
+    items.extend(parsed_trailing_comments);
 
-    return items.into();
+    return items;
 
     fn get_block_stmt_body(node: &SwitchCase) -> Option<Span> {
         let first_cons = node.cons.get(0);
@@ -2963,8 +2931,8 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Pri
         return None;
     }
 
-    fn parse_trailing_comments_for_case<'a>(node_span: Span, block_stmt_body: &Option<Span>, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn parse_trailing_comments_for_case<'a>(node_span: Span, block_stmt_body: &Option<Span>, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
         // parse the trailing comments as statements
         let trailing_comments = get_trailing_comments_as_statements(&node_span, context);
         if !trailing_comments.is_empty() {
@@ -2978,7 +2946,7 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Pri
                     is_equal_indent = is_equal_indent || comment.start_column(context) <= last_node.start_column(context);
                     let parsed_comment = parse_comment_based_on_last_node(&comment, &Some(&last_node), context);
 
-                    items.push(if !is_last_case && is_equal_indent {
+                    items.extend(if !is_last_case && is_equal_indent {
                         parsed_comment
                     } else {
                         parser_helpers::with_indent(parsed_comment)
@@ -2987,73 +2955,73 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Pri
                 }
             }
         }
-        return items.into();
+        return items;
     }
 }
 
-fn parse_throw_stmt<'a>(node: &'a ThrowStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("throw ".into());
-    items.push(parse_node((&node.arg).into(), context));
-    if context.config.throw_statement_semi_colon { items.push(";".into()); }
-    return items.into();
+fn parse_throw_stmt<'a>(node: &'a ThrowStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("throw ");
+    items.extend(parse_node((&node.arg).into(), context));
+    if context.config.throw_statement_semi_colon { items.push_str(";"); }
+    return items;
 }
 
-fn parse_try_stmt<'a>(node: &'a TryStmt, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_try_stmt<'a>(node: &'a TryStmt, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let brace_position = context.config.try_statement_brace_position;
     let next_control_flow_position = context.config.try_statement_next_control_flow_position;
     let mut last_block_span = node.block.span;
 
-    items.push("try".into());
-    items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+    items.push_str("try");
+    items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
         brace_position: brace_position,
         open_brace_token: context.token_finder.get_first_open_brace_token_within(&node.block),
         start_header_info: None,
     }, context));
-    items.push(parse_node((&node.block).into(), context));
+    items.extend(parse_node((&node.block).into(), context));
 
     if let Some(handler) = &node.handler {
-        items.push(parse_control_flow_separator(next_control_flow_position, &last_block_span, "catch", context));
+        items.extend(parse_control_flow_separator(next_control_flow_position, &last_block_span, "catch", context));
         last_block_span = handler.span;
-        items.push(parse_node(handler.into(), context));
+        items.extend(parse_node(handler.into(), context));
     }
 
     if let Some(finalizer) = &node.finalizer {
-        items.push(parse_control_flow_separator(next_control_flow_position, &last_block_span, "finally", context));
-        items.push("finally".into());
-        items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+        items.extend(parse_control_flow_separator(next_control_flow_position, &last_block_span, "finally", context));
+        items.push_str("finally");
+        items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
             brace_position: brace_position,
             open_brace_token: context.token_finder.get_first_open_brace_token_within(&finalizer),
             start_header_info: None,
         }, context));
-        items.push(parse_node(finalizer.into(), context));
+        items.extend(parse_node(finalizer.into(), context));
     }
 
-    return items.into();
+    return items;
 }
 
-fn parse_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    if node.declare { items.push("declare ".into()); }
-    items.push(match node.kind {
+fn parse_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    if node.declare { items.push_str("declare "); }
+    items.push_str(match node.kind {
         VarDeclKind::Const => "const ",
         VarDeclKind::Let => "let ",
         VarDeclKind::Var => "var ",
-    }.into());
+    });
 
     for (i, decl) in node.decls.iter().enumerate() {
         if i > 0 {
-            items.push(",".into());
-            items.push(PrintItem::SpaceOrNewLine);
+            items.push_str(",");
+            items.push_signal(Signal::SpaceOrNewLine);
         }
 
-        items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node(decl.into(), context))).into());
+        items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node(decl.into(), context))));
     }
 
-    if requires_semi_colon(&node.span, context) { items.push(";".into()); }
+    if requires_semi_colon(&node.span, context) { items.push_str(";"); }
 
-    return items.into();
+    return items;
 
     fn requires_semi_colon(var_decl_span: &Span, context: &mut Context) -> bool {
         let parent = context.parent();
@@ -3066,31 +3034,31 @@ fn parse_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> PrintItem
     }
 }
 
-fn parse_var_declarator<'a>(node: &'a VarDeclarator, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_var_declarator<'a>(node: &'a VarDeclarator, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
-    items.push(parse_node((&node.name).into(), context));
+    items.extend(parse_node((&node.name).into(), context));
 
     if let Some(init) = &node.init {
-        items.push(" = ".into());
-        items.push(parse_node(init.into(), context));
+        items.push_str(" = ");
+        items.extend(parse_node(init.into(), context));
     }
 
-    items.into()
+    items
 }
 
-fn parse_while_stmt<'a>(node: &'a WhileStmt, context: &mut Context<'a>) -> PrintItem {
+fn parse_while_stmt<'a>(node: &'a WhileStmt, context: &mut Context<'a>) -> PrintItems {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
-    let mut items = Vec::new();
-    items.push(start_header_info.clone().into());
-    items.push("while".into());
+    let mut items = PrintItems::new();
+    items.push_info(start_header_info.clone());
+    items.push_str("while");
     if context.config.while_statement_space_after_while_keyword {
-        items.push(" ".into());
+        items.push_str(" ");
     }
-    items.push(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
-    items.push(end_header_info.clone().into());
-    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.extend(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
+    items.push_info(end_header_info.clone());
+    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: context.config.while_statement_use_braces,
@@ -3101,143 +3069,143 @@ fn parse_while_stmt<'a>(node: &'a WhileStmt, context: &mut Context<'a>) -> Print
         start_header_info: Some(start_header_info),
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
-    return items.into();
+    return items;
 }
 
 /* types */
 
-fn parse_array_type<'a>(node: &'a TsArrayType, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.elem_type).into(), context));
-    items.push("[]".into());
-    return items.into();
+fn parse_array_type<'a>(node: &'a TsArrayType, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.elem_type).into(), context));
+    items.push_str("[]");
+    return items;
 }
 
-fn parse_conditional_type<'a>(node: &'a TsConditionalType, context: &mut Context<'a>) -> PrintItem {
+fn parse_conditional_type<'a>(node: &'a TsConditionalType, context: &mut Context<'a>) -> PrintItems {
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&node.check_type, &node.false_type, context);
     let is_parent_conditional_type = context.parent().kind() == NodeKind::TsConditionalType;
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
     // main area
-    items.push(parser_helpers::new_line_group(parse_node((&node.check_type).into(), context)));
-    items.push(PrintItem::SpaceOrNewLine);
-    items.push(conditions::indent_if_start_of_line({
-        let mut items = Vec::new();
-        items.push("extends ".into());
-        items.push(parser_helpers::new_line_group(parse_node((&node.extends_type).into(), context)));
-        items.into()
-    }).into());
-    items.push(PrintItem::SpaceOrNewLine);
-    items.push(conditions::indent_if_start_of_line({
-        let mut items = Vec::new();
-        items.push("? ".into());
-        items.push(parser_helpers::new_line_group(parse_node((&node.true_type).into(), context)));
-        items.into()
-    }).into());
+    items.extend(parser_helpers::new_line_group(parse_node((&node.check_type).into(), context)));
+    items.push_signal(Signal::SpaceOrNewLine);
+    items.push_condition(conditions::indent_if_start_of_line({
+        let mut items = PrintItems::new();
+        items.push_str("extends ");
+        items.extend(parser_helpers::new_line_group(parse_node((&node.extends_type).into(), context)));
+        items
+    }));
+    items.push_signal(Signal::SpaceOrNewLine);
+    items.push_condition(conditions::indent_if_start_of_line({
+        let mut items = PrintItems::new();
+        items.push_str("? ");
+        items.extend(parser_helpers::new_line_group(parse_node((&node.true_type).into(), context)));
+        items
+    }));
 
     // false type
-    items.push(if use_new_lines { PrintItem::NewLine } else { PrintItem::SpaceOrNewLine });
+    items.push_signal(if use_new_lines { Signal::NewLine } else { Signal::SpaceOrNewLine });
 
     let false_type_parsed = {
-        let mut items = Vec::new();
-        items.push(": ".into());
-        items.push(parser_helpers::new_line_group(parse_node((&node.false_type).into(), context)));
-        items.into()
+        let mut items = PrintItems::new();
+        items.push_str(": ");
+        items.extend(parser_helpers::new_line_group(parse_node((&node.false_type).into(), context)));
+        items
     };
 
     if is_parent_conditional_type {
-        items.push(false_type_parsed);
+        items.extend(false_type_parsed);
     } else {
-        items.push(conditions::indent_if_start_of_line(false_type_parsed).into());
+        items.push_condition(conditions::indent_if_start_of_line(false_type_parsed));
     }
 
-    return items.into();
+    return items;
 }
 
-fn parse_constructor_type<'a>(node: &'a TsConstructorType, context: &mut Context<'a>) -> PrintItem {
+fn parse_constructor_type<'a>(node: &'a TsConstructorType, context: &mut Context<'a>) -> PrintItems {
     let start_info = Info::new("startConstructorType");
-    let mut items = Vec::new();
-    items.push(start_info.clone().into());
-    items.push("new".into());
-    if context.config.constructor_type_space_after_new_keyword { items.push(" ".into()); }
+    let mut items = PrintItems::new();
+    items.push_info(start_info.clone());
+    items.push_str("new");
+    if context.config.constructor_type_space_after_new_keyword { items.push_str(" "); }
     if let Some(type_params) = &node.type_params {
-        items.push(parse_node(type_params.into(), context));
+        items.extend(parse_node(type_params.into(), context));
     }
-    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.constructor_type_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
             start_info,
             type_node: Some((&node.type_ann).into()),
             type_node_separator: Some({
-                let mut items = Vec::new();
-                items.push(PrintItem::SpaceOrNewLine);
-                items.push("=> ".into());
-                items.into()
+                let mut items = PrintItems::new();
+                items.push_signal(Signal::SpaceOrNewLine);
+                items.push_str("=> ");
+                items
             }),
         }, context)),
     }, context));
-    return items.into();
+    return items;
 }
 
-fn parse_function_type<'a>(node: &'a TsFnType, context: &mut Context<'a>) -> PrintItem {
+fn parse_function_type<'a>(node: &'a TsFnType, context: &mut Context<'a>) -> PrintItems {
     let start_info = Info::new("startFunctionType");
-    let mut items = Vec::new();
-    items.push(start_info.clone().into());
+    let mut items = PrintItems::new();
+    items.push_info(start_info.clone());
     if let Some(type_params) = &node.type_params {
-        items.push(parse_node(type_params.into(), context));
+        items.extend(parse_node(type_params.into(), context));
     }
-    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.function_type_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
             start_info,
             type_node: Some((&node.type_ann).into()),
             type_node_separator: {
-                let mut items = Vec::new();
-                items.push(PrintItem::SpaceOrNewLine);
-                items.push("=> ".into());
+                let mut items = PrintItems::new();
+                items.push_signal(Signal::SpaceOrNewLine);
+                items.push_str("=> ");
                 Some(items.into())
             },
         }, context)),
     }, context));
-    return items.into();
+    return items;
 }
 
-fn parse_import_type<'a>(node: &'a TsImportType, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("import(".into());
-    items.push(parse_node((&node.arg).into(), context));
-    items.push(")".into());
+fn parse_import_type<'a>(node: &'a TsImportType, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("import(");
+    items.extend(parse_node((&node.arg).into(), context));
+    items.push_str(")");
 
     if let Some(qualifier) = &node.qualifier {
-        items.push(".".into());
-        items.push(parse_node(qualifier.into(), context));
+        items.push_str(".");
+        items.extend(parse_node(qualifier.into(), context));
     }
 
     if let Some(type_args) = &node.type_args {
-        items.push(parse_node(type_args.into(), context));
+        items.extend(parse_node(type_args.into(), context));
     }
-    return items.into();
+    return items;
 }
 
-fn parse_indexed_access_type<'a>(node: &'a TsIndexedAccessType, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.obj_type).into(), context));
-    items.push("[".into());
-    items.push(parse_node((&node.index_type).into(), context));
-    items.push("]".into());
-    return items.into();
+fn parse_indexed_access_type<'a>(node: &'a TsIndexedAccessType, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.obj_type).into(), context));
+    items.push_str("[");
+    items.extend(parse_node((&node.index_type).into(), context));
+    items.push_str("]");
+    return items;
 }
 
-fn parse_infer_type<'a>(node: &'a TsInferType, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("infer ".into());
-    items.push(parse_node((&node.type_param).into(), context));
-    return items.into();
+fn parse_infer_type<'a>(node: &'a TsInferType, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("infer ");
+    items.extend(parse_node((&node.type_param).into(), context));
+    return items;
 }
 
-fn parse_intersection_type<'a>(node: &'a TsIntersectionType, context: &mut Context<'a>) -> PrintItem {
+fn parse_intersection_type<'a>(node: &'a TsIntersectionType, context: &mut Context<'a>) -> PrintItems {
     parse_union_or_intersection_type(UnionOrIntersectionType {
         span: node.span,
         types: &node.types,
@@ -3245,70 +3213,70 @@ fn parse_intersection_type<'a>(node: &'a TsIntersectionType, context: &mut Conte
     }, context)
 }
 
-fn parse_lit_type<'a>(node: &'a TsLitType, context: &mut Context<'a>) -> PrintItem {
+fn parse_lit_type<'a>(node: &'a TsLitType, context: &mut Context<'a>) -> PrintItems {
     parse_node((&node.lit).into(), context)
 }
 
-fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let start_info = Info::new("startMappedType");
     let end_info = Info::new("endMappedType");
     let open_brace_token = context.token_finder.get_first_open_brace_token_within(&node).expect("Expected to find an open brace token in the mapped type.");
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&open_brace_token, &node.type_param, context);
-    items.push(start_info.clone().into());
-    items.push("{".into());
-    items.push(if use_new_lines {
-        PrintItem::NewLine
+    items.push_info(start_info.clone());
+    items.push_str("{");
+    if use_new_lines {
+        items.push_signal(Signal::NewLine);
     } else {
-        conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info.clone(), Some(end_info.clone())).into()
-    });
-    items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group({
-        let mut items = Vec::new();
+        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info.clone(), Some(end_info.clone())));
+    }
+    items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group({
+        let mut items = PrintItems::new();
         if let Some(readonly) = node.readonly {
-            items.push(match readonly {
+            items.push_str(match readonly {
                 TruePlusMinus::True => "readonly ",
                 TruePlusMinus::Plus => "+readonly ",
                 TruePlusMinus::Minus => "-readonly ",
-            }.into());
+            });
         }
-        items.push("[".into());
-        items.push(parse_node((&node.type_param).into(), context));
-        items.push("]".into());
+        items.push_str("[");
+        items.extend(parse_node((&node.type_param).into(), context));
+        items.push_str("]");
         if let Some(optional) = node.optional {
-            items.push(match optional {
+            items.push_str(match optional {
                 TruePlusMinus::True => "?",
                 TruePlusMinus::Plus => "+?",
                 TruePlusMinus::Minus => "-?",
-            }.into());
+            });
         }
-        items.push(parse_type_annotation_with_colon_if_exists_for_type(&node.type_ann, context));
+        items.extend(parse_type_annotation_with_colon_if_exists_for_type(&node.type_ann, context));
         if context.config.mapped_type_semi_colon {
-            items.push(";".into());
+            items.push_str(";");
         }
-        items.into()
-    })).into());
-    items.push(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(end_info.clone())).into());
-    items.push("}".into());
-    items.push(end_info.into());
-    return items.into();
+        items
+    })));
+    items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(end_info.clone())));
+    items.push_str("}");
+    items.push_info(end_info);
+    return items;
 }
 
-fn parse_optional_type<'a>(node: &'a TsOptionalType, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.type_ann).into(), context));
-    items.push("?".into());
-    return items.into();
+fn parse_optional_type<'a>(node: &'a TsOptionalType, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.type_ann).into(), context));
+    items.push_str("?");
+    return items;
 }
 
-fn parse_qualified_name<'a>(node: &'a TsQualifiedName, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.left).into(), context));
-    items.push(".".into());
-    items.push(parse_node((&node.right).into(), context));
-    return items.into();
+fn parse_qualified_name<'a>(node: &'a TsQualifiedName, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.left).into(), context));
+    items.push_str(".");
+    items.extend(parse_node((&node.right).into(), context));
+    return items;
 }
 
-fn parse_parenthesized_type<'a>(node: &'a TsParenthesizedType, context: &mut Context<'a>) -> PrintItem {
+fn parse_parenthesized_type<'a>(node: &'a TsParenthesizedType, context: &mut Context<'a>) -> PrintItems {
     conditions::with_indent_if_start_of_line_indented(parse_node_in_parens(
         (&node.type_ann).into(),
         |context| parse_node((&node.type_ann).into(), context),
@@ -3316,14 +3284,14 @@ fn parse_parenthesized_type<'a>(node: &'a TsParenthesizedType, context: &mut Con
     )).into()
 }
 
-fn parse_rest_type<'a>(node: &'a TsRestType, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("...".into());
-    items.push(parse_node((&node.type_ann).into(), context));
-    return items.into();
+fn parse_rest_type<'a>(node: &'a TsRestType, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("...");
+    items.extend(parse_node((&node.type_ann).into(), context));
+    return items;
 }
 
-fn parse_tuple_type<'a>(node: &'a TsTupleType, context: &mut Context<'a>) -> PrintItem {
+fn parse_tuple_type<'a>(node: &'a TsTupleType, context: &mut Context<'a>) -> PrintItems {
     parse_array_like_nodes(ParseArrayLikeNodesOptions {
         parent_span: node.span,
         elements: node.elem_types.iter().map(|x| Some(x.into())).collect(),
@@ -3331,78 +3299,77 @@ fn parse_tuple_type<'a>(node: &'a TsTupleType, context: &mut Context<'a>) -> Pri
     }, context)
 }
 
-fn parse_type_ann<'a>(node: &'a TsTypeAnn, context: &mut Context<'a>) -> PrintItem {
+fn parse_type_ann<'a>(node: &'a TsTypeAnn, context: &mut Context<'a>) -> PrintItems {
     parse_node((&node.type_ann).into(), context)
 }
 
-fn parse_type_param<'a>(node: &'a TsTypeParam, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_type_param<'a>(node: &'a TsTypeParam, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
-    items.push(parse_node((&node.name).into(), context));
+    items.extend(parse_node((&node.name).into(), context));
 
     if let Some(constraint) = &node.constraint {
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
-            items.push(if context.parent().kind() == NodeKind::TsMappedType {
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str(if context.parent().kind() == NodeKind::TsMappedType {
                 "in "
             } else {
                 "extends "
-            }.into());
-            items.push(parse_node(constraint.into(), context));
-            items.into()
-        }).into());
+            });
+            items.extend(parse_node(constraint.into(), context));
+            items
+        }));
     }
 
     if let Some(default) = &node.default {
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line({
-            let mut items = Vec::new();
-            items.push("= ".into());
-            items.push(parse_node(default.into(), context));
-            items.into()
-        }).into());
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line({
+            let mut items = PrintItems::new();
+            items.push_str("= ");
+            items.extend(parse_node(default.into(), context));
+            items
+        }));
     }
 
-    return items.into();
+    return items;
 }
 
-fn parse_type_param_instantiation<'a>(node: TypeParamNode<'a>, context: &mut Context<'a>) -> PrintItem {
+fn parse_type_param_instantiation<'a>(node: TypeParamNode<'a>, context: &mut Context<'a>) -> PrintItems {
     let parent_span = node.span();
     let params = node.params();
     let use_new_lines = get_use_new_lines(&parent_span, &params, context);
     let parsed_params = parse_parameter_list(params, use_new_lines, context);
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push("<".into());
-    items.push(if use_new_lines {
+    items.push_str("<");
+    items.extend(if use_new_lines {
         parser_helpers::surround_with_new_lines(parsed_params)
     } else {
         parsed_params
     });
-    items.push(">".into());
+    items.push_str(">");
 
-    return items.into();
+    return items;
 
-    fn parse_parameter_list<'a>(params: Vec<Node<'a>>, use_new_lines: bool, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn parse_parameter_list<'a>(params: Vec<Node<'a>>, use_new_lines: bool, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
         let params_count = params.len();
 
         for (i, param) in params.into_iter().enumerate() {
             if i > 0 {
-                items.push(if use_new_lines { PrintItem::NewLine } else { PrintItem::SpaceOrNewLine });
+                items.push_signal(if use_new_lines { Signal::NewLine } else { Signal::SpaceOrNewLine });
             }
 
-            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node_with_inner_parse(param, context, move |item| {
+            items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node_with_inner_parse(param, context, move |mut items| {
                 if i < params_count - 1 {
-                    vec![item, ",".into()].into()
-                } else {
-                    item
+                    items.push_str(",");
                 }
-            }))).into());
+                items
+            }))));
         }
 
-        items.into()
+        items
     }
 
     fn get_use_new_lines(parent_span: &Span, params: &Vec<Node>, context: &mut Context) -> bool {
@@ -3416,43 +3383,43 @@ fn parse_type_param_instantiation<'a>(node: TypeParamNode<'a>, context: &mut Con
     }
 }
 
-fn parse_type_operator<'a>(node: &'a TsTypeOperator, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(match node.op {
+fn parse_type_operator<'a>(node: &'a TsTypeOperator, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str(match node.op {
         TsTypeOperatorOp::KeyOf => "keyof ",
         TsTypeOperatorOp::Unique => "unique ",
         TsTypeOperatorOp::ReadOnly => "readonly ",
-    }.into());
-    items.push(parse_node((&node.type_ann).into(), context));
-    return items.into();
+    });
+    items.extend(parse_node((&node.type_ann).into(), context));
+    return items;
 }
 
-fn parse_type_predicate<'a>(node: &'a TsTypePredicate, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    if node.asserts { items.push("asserts ".into()); }
-    items.push(parse_node((&node.param_name).into(), context));
-    items.push(" is ".into());
-    items.push(parse_node((&node.type_ann).into(), context));
-    return items.into();
+fn parse_type_predicate<'a>(node: &'a TsTypePredicate, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    if node.asserts { items.push_str("asserts "); }
+    items.extend(parse_node((&node.param_name).into(), context));
+    items.push_str(" is ");
+    items.extend(parse_node((&node.type_ann).into(), context));
+    return items;
 }
 
-fn parse_type_query<'a>(node: &'a TsTypeQuery, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push("typeof ".into());
-    items.push(parse_node((&node.expr_name).into(), context));
-    return items.into();
+fn parse_type_query<'a>(node: &'a TsTypeQuery, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.push_str("typeof ");
+    items.extend(parse_node((&node.expr_name).into(), context));
+    return items;
 }
 
-fn parse_type_reference<'a>(node: &'a TsTypeRef, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
-    items.push(parse_node((&node.type_name).into(), context));
+fn parse_type_reference<'a>(node: &'a TsTypeRef, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
+    items.extend(parse_node((&node.type_name).into(), context));
     if let Some(type_params) = &node.type_params {
-        items.push(parse_node(type_params.into(), context));
+        items.extend(parse_node(type_params.into(), context));
     }
-    return items.into();
+    return items;
 }
 
-fn parse_union_type<'a>(node: &'a TsUnionType, context: &mut Context<'a>) -> PrintItem {
+fn parse_union_type<'a>(node: &'a TsUnionType, context: &mut Context<'a>) -> PrintItems {
     parse_union_or_intersection_type(UnionOrIntersectionType {
         span: node.span,
         types: &node.types,
@@ -3466,8 +3433,8 @@ struct UnionOrIntersectionType<'a> {
     pub is_union: bool,
 }
 
-fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&node.types[0], &node.types[1], context);
     let separator = if node.is_union { "|" } else { "&" };
     let is_ancestor_parenthesized_type = get_is_ancestor_parenthesized_type(context);
@@ -3476,7 +3443,7 @@ fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, conte
 
     for (i, type_node) in node.types.iter().enumerate() {
         if i > 0 {
-            items.push(if use_new_lines { PrintItem::NewLine } else { PrintItem::SpaceOrNewLine });
+            items.push_signal(if use_new_lines { Signal::NewLine } else { Signal::SpaceOrNewLine });
         }
 
         let separator_token = if let Some(last_type_node_span) = last_type_node_span.replace(type_node.span()) {
@@ -3485,36 +3452,34 @@ fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, conte
             None
         };
         let parsed_node = {
-            let mut items = Vec::new();
+            let mut items = PrintItems::new();
             let after_separator_info = Info::new("afterSeparatorInfo");
             if i > 0 {
-                items.push(separator.into());
-                items.push(after_separator_info.clone().into());
+                items.push_str(separator);
+                items.push_info(after_separator_info.clone());
             }
             if let Some(separator_token) = separator_token {
-                if let Some(parsed_comments) = parse_trailing_comments(&separator_token, context) {
-                    items.push(parsed_comments);
-                }
+                items.extend(parse_trailing_comments(&separator_token, context));
             }
             if i > 0 {
-                items.push(Condition::new("afterSeparatorSpace", ConditionProperties {
+                items.push_condition(Condition::new("afterSeparatorSpace", ConditionProperties {
                     condition: Box::new(move |condition_context| condition_resolvers::is_on_same_line(condition_context, &after_separator_info)),
                     true_path: Some(" ".into()),
                     false_path: None
-                }).into());
+                }));
             }
-            items.push(parse_node(type_node.into(), context));
-            items.into()
+            items.extend(parse_node(type_node.into(), context));
+            items
         };
         // probably something better needs to be done here, but htis is good enough for now
         if is_ancestor_parenthesized_type || i == 0 && !is_parent_union_or_intersection_type {
-            items.push(parsed_node);
+            items.extend(parsed_node);
         } else {
-            items.push(conditions::indent_if_start_of_line(parsed_node).into());
+            items.push_condition(conditions::indent_if_start_of_line(parsed_node));
         }
     }
 
-    return items.into();
+    return items;
 
     fn get_separator_token<'a>(separator: &str, last_type_node: &dyn Ranged, parent: &dyn Ranged, context: &mut Context<'a>) -> Option<&'a TokenAndSpan> {
         let token = context.token_finder.get_first_operator_after(last_type_node, separator);
@@ -3540,91 +3505,89 @@ fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, conte
 
 /* comments */
 
-fn parse_leading_comments<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Option<PrintItem> {
+fn parse_leading_comments<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> PrintItems {
     let leading_comments = node.leading_comments(context);
     parse_comments_as_leading(node, leading_comments, context)
 }
 
-fn parse_comments_as_leading<'a>(node: &dyn Spanned, comments: CommentsIterator<'a>, context: &mut Context<'a>) -> Option<PrintItem> {
-    let mut items = Vec::new();
+fn parse_comments_as_leading<'a>(node: &dyn Spanned, comments: CommentsIterator<'a>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if let Some(last_comment) = comments.get_last_comment() {
         let last_comment_previously_handled = context.has_handled_comment(&last_comment);
 
-        if let Some(parsed_comments) = parse_comment_collection(comments, None, context) {
-            items.push(parsed_comments);
-        }
+        items.extend(parse_comment_collection(comments, None, context));
 
         // todo: this doesn't seem exactly right...
         if !last_comment_previously_handled {
             let node_start_line = node.start_line(context);
             let last_comment_end_line = last_comment.end_line(context);
             if node_start_line > last_comment_end_line {
-                items.push(PrintItem::NewLine);
+                items.push_signal(Signal::NewLine);
 
                 if node_start_line - 1 > last_comment_end_line {
-                    items.push(PrintItem::NewLine);
+                    items.push_signal(Signal::NewLine);
                 }
             }
             else if last_comment.kind == CommentKind::Block && node_start_line == last_comment_end_line {
-                items.push(" ".into());
+                items.push_str(" ");
             }
         }
     }
 
-    if items.is_empty() { None } else { Some(items.into()) }
+    items
 }
 
-fn parse_trailing_comments_as_statements<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Option<PrintItem> {
+fn parse_trailing_comments_as_statements<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> PrintItems {
     let unhandled_comments = get_trailing_comments_as_statements(node, context);
     parse_comment_collection(unhandled_comments.into_iter(), Some(node), context)
 }
 
 fn get_trailing_comments_as_statements<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Vec<&'a Comment> {
-    let mut items = Vec::new();
+    let mut comments = Vec::new();
     let node_end_line = node.end_line(context);
     for comment in node.trailing_comments(context) {
         if !context.has_handled_comment(&comment) && node_end_line < comment.end_line(context) {
-            items.push(comment);
+            comments.push(comment);
         }
     }
-    items.into()
+    comments
 }
 
-fn parse_comment_collection<'a, CIter>(comments: CIter, last_node: Option<&dyn Spanned>, context: &mut Context<'a>) -> Option<PrintItem> where CIter : Iterator<Item=&'a Comment> {
+fn parse_comment_collection<'a, CIter>(comments: CIter, last_node: Option<&dyn Spanned>, context: &mut Context<'a>) -> PrintItems where CIter : Iterator<Item=&'a Comment> {
     let mut last_node = last_node;
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
     for comment in comments {
         if !context.has_handled_comment(comment) {
-            items.push(parse_comment_based_on_last_node(comment, &last_node, context));
+            items.extend(parse_comment_based_on_last_node(comment, &last_node, context));
             last_node = Some(comment);
         }
     }
-    if items.is_empty() { None } else { Some(items.into()) }
+    items
 }
 
-fn parse_comment_based_on_last_node(comment: &Comment, last_node: &Option<&dyn Spanned>, context: &mut Context) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_comment_based_on_last_node(comment: &Comment, last_node: &Option<&dyn Spanned>, context: &mut Context) -> PrintItems {
+    let mut items = PrintItems::new();
 
     if let Some(last_node) = last_node {
         if comment.start_line(context) > last_node.end_line(context) {
-            items.push(PrintItem::NewLine);
+            items.push_signal(Signal::NewLine);
 
             if comment.start_line(context) > last_node.end_line(context) + 1 {
-                items.push(PrintItem::NewLine);
+                items.push_signal(Signal::NewLine);
             }
         } else if comment.kind == CommentKind::Line || last_node.text(context).starts_with("/*") {
-            items.push(" ".into());
+            items.push_str(" ");
         }
     }
 
     if let Some(parsed_comment) = parse_comment(&comment, context) {
-        items.push(parsed_comment);
+        items.extend(parsed_comment);
     }
 
-    return items.into();
+    return items;
 }
 
-fn parse_comment(comment: &Comment, context: &mut Context) -> Option<PrintItem> {
+fn parse_comment(comment: &Comment, context: &mut Context) -> Option<PrintItems> {
     // only parse if handled
     if context.has_handled_comment(comment) {
         return None;
@@ -3637,19 +3600,19 @@ fn parse_comment(comment: &Comment, context: &mut Context) -> Option<PrintItem> 
         CommentKind::Line => parse_comment_line(comment),
     });
 
-    fn parse_comment_block(comment: &Comment) -> PrintItem {
-        let mut items = Vec::new();
-        items.push("/*".into());
-        items.push(parse_raw_string(&comment.text));
-        items.push("*/".into());
-        items.into()
+    fn parse_comment_block(comment: &Comment) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.push_str("/*");
+        items.extend(parse_raw_string(&comment.text));
+        items.push_str("*/");
+        items
     }
 
-    fn parse_comment_line(comment: &Comment) -> PrintItem {
-        return vec![
-            get_comment_text(&comment.text).into(),
-            PrintItem::ExpectNewLine
-        ].into();
+    fn parse_comment_line(comment: &Comment) -> PrintItems {
+        let mut items = PrintItems::new();
+        items.push_str(&get_comment_text(&comment.text));
+        items.push_signal(Signal::ExpectNewLine);
+        return items;
 
         fn get_comment_text(original_text: &String) -> String {
             let non_slash_index = get_first_non_slash_index(&original_text);
@@ -3679,22 +3642,22 @@ fn parse_comment(comment: &Comment, context: &mut Context) -> Option<PrintItem> 
     }
 }
 
-fn parse_first_line_trailing_comments<'a>(node: &dyn Spanned, first_member: Option<&dyn Spanned>, context: &mut Context<'a>) -> Option<PrintItem> {
-    let mut items = Vec::new();
+fn parse_first_line_trailing_comments<'a>(node: &dyn Spanned, first_member: Option<&dyn Spanned>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     let node_start_line = node.start_line(context);
 
     for comment in get_comments(&node, &first_member, context) {
         if comment.start_line(context) == node_start_line {
             if let Some(parsed_comment) = parse_comment(comment, context) {
                 if comment.kind == CommentKind::Line {
-                    items.push(" ".into());
+                    items.push_str(" ");
                 }
-                items.push(parsed_comment);
+                items.extend(parsed_comment);
             }
         }
     }
 
-    return if items.is_empty() { None } else { Some(items.into()) };
+    return items;
 
     fn get_comments<'a>(node: &dyn Spanned, first_member: &Option<&dyn Spanned>, context: &mut Context<'a>) -> Vec<&'a Comment> {
         let mut comments = Vec::new();
@@ -3707,30 +3670,28 @@ fn parse_first_line_trailing_comments<'a>(node: &dyn Spanned, first_member: Opti
     }
 }
 
-fn parse_trailing_comments<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Option<PrintItem> {
+fn parse_trailing_comments<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> PrintItems {
     // todo: handle comments for object expr, arrayexpr, and tstupletype?
     let trailing_comments = node.trailing_comments(context);
     parse_comments_as_trailing(node, trailing_comments, context)
 }
 
-fn parse_comments_as_trailing<'a>(node: &dyn Spanned, trailing_comments: CommentsIterator<'a>, context: &mut Context<'a>) -> Option<PrintItem> {
+fn parse_comments_as_trailing<'a>(node: &dyn Spanned, trailing_comments: CommentsIterator<'a>, context: &mut Context<'a>) -> PrintItems {
     // use the roslyn definition of trailing comments
     let node_end_line = node.end_line(context);
     let trailing_comments_on_same_line = trailing_comments.into_iter().filter(|c| c.start_line(context) == node_end_line).collect::<Vec<&'a Comment>>();
     let first_unhandled_comment = trailing_comments_on_same_line.iter().filter(|c| !context.has_handled_comment(&c)).next();
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
     if let Some(first_unhandled_comment) = first_unhandled_comment {
         if first_unhandled_comment.kind == CommentKind::Block {
-            items.push(" ".into());
+            items.push_str(" ");
         }
     }
 
-    if let Some(parsed_comments) = parse_comment_collection(trailing_comments_on_same_line.into_iter(), Some(node), context) {
-        items.push(parsed_comments);
-    }
+    items.extend(parse_comment_collection(trailing_comments_on_same_line.into_iter(), Some(node), context));
 
-    return if items.is_empty() { None } else { Some(items.into()) };
+    items
 }
 
 fn get_jsx_empty_expr_comments<'a>(node: &JSXEmptyExpr, context: &mut Context<'a>) -> CommentsIterator<'a> {
@@ -3745,60 +3706,59 @@ struct ParseArrayLikeNodesOptions<'a> {
     trailing_commas: TrailingCommas,
 }
 
-fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mut Context<'a>) -> PrintItem {
+fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mut Context<'a>) -> PrintItems {
     let parent_span = opts.parent_span;
     let elements = opts.elements;
     let use_new_lines = get_use_new_lines(&parent_span, &elements, context);
     let force_trailing_commas = get_force_trailing_commas(opts.trailing_commas, use_new_lines);
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push("[".into());
+    items.push_str("[");
     if !elements.is_empty() {
-        items.push(parse_elements(&parent_span, elements, use_new_lines, force_trailing_commas, context));
+        items.extend(parse_elements(&parent_span, elements, use_new_lines, force_trailing_commas, context));
     }
-    items.push("]".into());
+    items.push_str("]");
 
-    return items.into();
+    return items;
 
-    fn parse_elements<'a>(parent_span: &Span, elements: Vec<Option<Node<'a>>>, use_new_lines: bool, force_trailing_commas: bool, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn parse_elements<'a>(parent_span: &Span, elements: Vec<Option<Node<'a>>>, use_new_lines: bool, force_trailing_commas: bool, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
         let elements_len = elements.len();
 
-        if use_new_lines { items.push(PrintItem::NewLine); }
+        if use_new_lines { items.push_signal(Signal::NewLine); }
 
         for (i, element) in elements.into_iter().enumerate() {
             if i > 0 && !use_new_lines {
-                items.push(PrintItem::SpaceOrNewLine);
+                items.push_signal(Signal::SpaceOrNewLine);
             }
 
             let has_comma = force_trailing_commas || i < elements_len - 1;
-            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_element(&parent_span, element, has_comma, context))).into());
+            items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_element(&parent_span, element, has_comma, context))));
 
-            if use_new_lines { items.push(PrintItem::NewLine); }
+            if use_new_lines { items.push_signal(Signal::NewLine); }
         }
 
-        return items.into();
+        return items;
     }
 
-    fn parse_element<'a>(parent_span: &Span, element: Option<Node<'a>>, has_comma: bool, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn parse_element<'a>(parent_span: &Span, element: Option<Node<'a>>, has_comma: bool, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
         let comma_token = get_comma_token(parent_span, &element, context);
 
         if let Some(element) = element {
-            items.push(parse_node_with_inner_parse(element, context, move |item| {
-                if has_comma { vec![item, ",".into()].into() } else { item }
+            items.extend(parse_node_with_inner_parse(element, context, move |mut items| {
+                if has_comma { items.push_str(","); }
+                items
             }));
         } else if has_comma {
-            items.push(",".into());
+            items.push_str(",");
         }
 
         // get the trailing comments after the comma token
         if let Some(comma_token) = &comma_token {
-            if let Some(parsed_comments) = parse_trailing_comments(comma_token, context) {
-                items.push(parsed_comments);
-            }
+            items.extend(parse_trailing_comments(comma_token, context));
         }
-        return items.into();
+        return items;
 
         fn get_comma_token<'a>(parent_span: &Span, element: &Option<Node<'a>>, context: &mut Context<'a>) -> Option<&'a TokenAndSpan> {
             if let Some(element) = &element {
@@ -3848,30 +3808,28 @@ struct ParseMemberedBodyOptions<'a, FShouldUseBlankLine> where FShouldUseBlankLi
 fn parse_membered_body<'a, FShouldUseBlankLine>(
     opts: ParseMemberedBodyOptions<'a, FShouldUseBlankLine>,
     context: &mut Context<'a>
-) -> PrintItem
+) -> PrintItems
     where FShouldUseBlankLine : Fn(&Node, &Node, &mut Context) -> bool
 {
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
     let open_brace_token = context.token_finder.get_first_open_brace_token_before(&if opts.members.is_empty() { opts.span.hi() } else { opts.members[0].lo() });
     let close_brace_token_pos = BytePos(opts.span.hi().0 - 1);
 
-    items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+    items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
         brace_position: opts.brace_position,
         open_brace_token: open_brace_token,
         start_header_info: opts.start_header_info,
     }, context));
 
-    items.push("{".into());
-    if let Some(parsed_comments) = parse_trailing_comments(&open_brace_token, context) {
-        items.push(parsed_comments);
-    }
-    items.push(parser_helpers::with_indent({
-        let mut items = Vec::new();
+    items.push_str("{");
+    items.extend(parse_trailing_comments(&open_brace_token, context));
+    items.extend(parser_helpers::with_indent({
+        let mut items = PrintItems::new();
         if !opts.members.is_empty() || close_brace_token_pos.leading_comments(context).any(|c| !context.has_handled_comment(&c)) {
-            items.push(PrintItem::NewLine);
+            items.push_signal(Signal::NewLine);
         }
 
-        items.push(parse_statements_or_members(ParseStatementsOrMembersOptions {
+        items.extend(parse_statements_or_members(ParseStatementsOrMembersOptions {
             inner_span: Span::new(open_brace_token.hi(), close_brace_token_pos.lo(), Default::default()),
             items: opts.members.into_iter().map(|node| (node, None)).collect(),
             should_use_space: None,
@@ -3880,15 +3838,15 @@ fn parse_membered_body<'a, FShouldUseBlankLine>(
             trailing_commas: opts.trailing_commas,
         }, context));
 
-        items.into()
+        items
     }));
-    items.push(PrintItem::NewLine);
-    items.push("}".into());
+    items.push_signal(Signal::NewLine);
+    items.push_str("}");
 
-    items.into()
+    items
 }
 
-fn parse_statements<'a>(inner_span: Span, stmts: Vec<Node<'a>>, context: &mut Context<'a>) -> PrintItem {
+fn parse_statements<'a>(inner_span: Span, stmts: Vec<Node<'a>>, context: &mut Context<'a>) -> PrintItems {
     parse_statements_or_members(ParseStatementsOrMembersOptions {
         inner_span,
         items: stmts.into_iter().map(|stmt| (stmt, None)).collect(),
@@ -3901,7 +3859,7 @@ fn parse_statements<'a>(inner_span: Span, stmts: Vec<Node<'a>>, context: &mut Co
 
 struct ParseStatementsOrMembersOptions<'a, FShouldUseBlankLine> where FShouldUseBlankLine : Fn(&Node, &Node, &mut Context) -> bool {
     inner_span: Span,
-    items: Vec<(Node<'a>, Option<PrintItem>)>,
+    items: Vec<(Node<'a>, Option<PrintItems>)>,
     should_use_space: Option<Box<dyn Fn(&Node, &Node, &mut Context) -> bool>>,
     should_use_new_line: Option<Box<dyn Fn(&Node, &Node, &mut Context) -> bool>>,
     should_use_blank_line: FShouldUseBlankLine,
@@ -3911,66 +3869,59 @@ struct ParseStatementsOrMembersOptions<'a, FShouldUseBlankLine> where FShouldUse
 fn parse_statements_or_members<'a, FShouldUseBlankLine>(
     opts: ParseStatementsOrMembersOptions<'a, FShouldUseBlankLine>,
     context: &mut Context<'a>
-) -> PrintItem where FShouldUseBlankLine : Fn(&Node, &Node, &mut Context) -> bool
+) -> PrintItems where FShouldUseBlankLine : Fn(&Node, &Node, &mut Context) -> bool
 {
     let mut last_node: Option<Node> = None;
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
     let children_len = opts.items.len();
 
     for (i, (node, optional_print_items)) in opts.items.into_iter().enumerate() {
         if let Some(last_node) = last_node {
             if should_use_new_line(&opts.should_use_new_line, &last_node, &node, context) {
-                items.push(PrintItem::NewLine);
+                items.push_signal(Signal::NewLine);
 
                 if (opts.should_use_blank_line)(&last_node, &node, context) {
-                    items.push(PrintItem::NewLine);
+                    items.push_signal(Signal::NewLine);
                 }
             }
             else if let Some(should_use_space) = &opts.should_use_space {
                 if should_use_space(&last_node, &node, context) {
-                    items.push(PrintItem::SpaceOrNewLine);
+                    items.push_signal(Signal::SpaceOrNewLine);
                 }
             }
         }
 
         let end_info = Info::new("endStatementOrMemberInfo");
         context.end_statement_or_member_infos.push(end_info.clone());
-        items.push(if let Some(print_items) = optional_print_items {
+        items.extend(if let Some(print_items) = optional_print_items {
             print_items
         } else {
             let trailing_commas = opts.trailing_commas;
-            parse_node_with_inner_parse(node.clone(), context, move |item| {
+            parse_node_with_inner_parse(node.clone(), context, move |mut items| {
                 if let Some(trailing_commas) = trailing_commas {
                     let force_trailing_commas = get_force_trailing_commas(trailing_commas, true);
                     if force_trailing_commas || i < children_len - 1 {
-                        vec![item, ",".into()].into()
-                    } else {
-                        item
+                        items.push_str(",");
                     }
-                } else {
-                    item
                 }
+                items
             })
         });
-        items.push(end_info.into());
+        items.push_info(end_info);
         context.end_statement_or_member_infos.pop();
 
         last_node = Some(node);
     }
 
     if let Some(last_node) = &last_node {
-        if let Some(parsed_comments) = parse_trailing_comments_as_statements(last_node, context) {
-            items.push(parsed_comments);
-        }
+        items.extend(parse_trailing_comments_as_statements(last_node, context));
     }
 
     if children_len == 0 {
-        if let Some(parsed_comments) = parse_comment_collection(opts.inner_span.hi().leading_comments(context), None, context) {
-            items.push(parsed_comments);
-        }
+        items.extend(parse_comment_collection(opts.inner_span.hi().leading_comments(context), None, context));
     }
 
-    return items.into();
+    return items;
 
     fn should_use_new_line(
         should_use_new_line: &Option<Box<dyn Fn(&Node, &Node, &mut Context) -> bool>>,
@@ -3988,10 +3939,10 @@ fn parse_statements_or_members<'a, FShouldUseBlankLine>(
 struct ParseParametersOrArgumentsOptions<'a> {
     nodes: Vec<Node<'a>>,
     force_multi_line_when_multiple_lines: bool,
-    custom_close_paren: Option<PrintItem>,
+    custom_close_paren: Option<PrintItems>,
 }
 
-fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>, context: &mut Context<'a>) -> PrintItem {
+fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>, context: &mut Context<'a>) -> PrintItems {
     let nodes = opts.nodes;
     let start_info = Info::new("startParamsOrArgs");
     let end_info = Info::new("endParamsOrArgs");
@@ -4010,27 +3961,27 @@ fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>
         }
     };
 
-    let mut items = Vec::new();
-    items.push(start_info.into());
-    items.push("(".into());
+    let mut items = PrintItems::new();
+    items.push_info(start_info);
+    items.push_str("(");
 
-    let param_list = parse_comma_separated_values(nodes, is_multi_line_or_hanging.clone(), context).into_rc();
-    items.push(Condition::new("multiLineOrHanging", ConditionProperties {
+    let param_list = parse_comma_separated_values(nodes, is_multi_line_or_hanging.clone(), context);
+    items.push_condition(Condition::new("multiLineOrHanging", ConditionProperties {
         condition: Box::new(is_multi_line_or_hanging),
-        true_path: Some(surround_with_new_lines(with_indent(param_list.clone().into()))),
-        false_path: Some(param_list.into()),
-    }).into());
+        true_path: Some(surround_with_new_lines(with_indent(param_list.clone()))),
+        false_path: Some(param_list),
+    }));
 
     if let Some(custom_close_paren) = opts.custom_close_paren {
-        items.push(custom_close_paren);
+        items.extend(custom_close_paren);
     }
     else {
-        items.push(")".into());
+        items.push_str(")");
     }
 
-    items.push(end_info.into());
+    items.push_info(end_info);
 
-    return items.into();
+    return items;
 
     fn get_use_new_lines(nodes: &Vec<Node>, context: &mut Context) -> bool {
         if nodes.is_empty() {
@@ -4052,19 +4003,19 @@ fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>
 struct ParseCloseParenWithTypeOptions<'a> {
     start_info: Info,
     type_node: Option<Node<'a>>,
-    type_node_separator: Option<PrintItem>,
+    type_node_separator: Option<PrintItems>,
 }
 
-fn parse_close_paren_with_type<'a>(opts: ParseCloseParenWithTypeOptions<'a>, context: &mut Context<'a>) -> PrintItem {
+fn parse_close_paren_with_type<'a>(opts: ParseCloseParenWithTypeOptions<'a>, context: &mut Context<'a>) -> PrintItems {
     // todo: clean this up a bit
     let type_node_start_info = Info::new("typeNodeStart");
     let has_type_node = opts.type_node.is_some();
     let type_node_end_info = Info::new("typeNodeEnd");
     let start_info = opts.start_info;
     let parsed_type_node = parse_type_node(opts.type_node, opts.type_node_separator, type_node_start_info.clone(), type_node_end_info.clone(), context);
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push(Condition::new("newLineIfHeaderHangingAndTypeNodeMultipleLines", ConditionProperties {
+    items.push_condition(Condition::new("newLineIfHeaderHangingAndTypeNodeMultipleLines", ConditionProperties {
         condition: Box::new(move |context| {
             if !has_type_node { return Some(false); }
 
@@ -4075,33 +4026,33 @@ fn parse_close_paren_with_type<'a>(opts: ParseCloseParenWithTypeOptions<'a>, con
             }
             return None;
         }),
-        true_path: Some(PrintItem::NewLine),
+        true_path: Some(Signal::NewLine.into()),
         false_path: None,
-    }).into());
-    items.push(")".into());
-    items.push(parsed_type_node);
-    return items.into();
+    }));
+    items.push_str(")");
+    items.extend(parsed_type_node);
+    return items;
 
     fn parse_type_node<'a>(
         type_node: Option<Node<'a>>,
-        type_node_separator: Option<PrintItem>,
+        type_node_separator: Option<PrintItems>,
         type_node_start_info: Info,
         type_node_end_info: Info,
         context: &mut Context<'a>
-    ) -> PrintItem {
-        let mut items = Vec::new();
+    ) -> PrintItems {
+        let mut items = PrintItems::new();
         if let Some(type_node) = type_node {
-            items.push(type_node_start_info.into());
+            items.push_info(type_node_start_info);
             if let Some(type_node_separator) = type_node_separator {
-                items.push(type_node_separator);
+                items.extend(type_node_separator);
             } else {
-                if context.config.type_annotation_space_before_colon { items.push(" ".into()); }
-                items.push(": ".into());
+                if context.config.type_annotation_space_before_colon { items.push_str(" "); }
+                items.push_str(": ");
             }
-            items.push(parse_node(type_node.into(), context));
-            items.push(type_node_end_info.into());
+            items.extend(parse_node(type_node.into(), context));
+            items.push_info(type_node_end_info);
         }
-        return items.into();
+        return items;
     }
 }
 
@@ -4109,8 +4060,8 @@ fn parse_comma_separated_values<'a>(
     values: Vec<Node<'a>>,
     multi_line_or_hanging_condition_resolver: impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static,
     context: &mut Context<'a>
-) -> PrintItem {
-    let mut items = Vec::new();
+) -> PrintItems {
+    let mut items = PrintItems::new();
     let values_count = values.len();
 
     for (i, value) in values.into_iter().enumerate() {
@@ -4118,71 +4069,67 @@ fn parse_comma_separated_values<'a>(
         let parsed_value = parse_value(value, has_comma, context);
 
         if i == 0 {
-            items.push(parsed_value);
+            items.extend(parsed_value);
         } else {
-            let parsed_value = parsed_value.into_rc();
-            items.push(Condition::new("multiLineOrHangingCondition", ConditionProperties {
+            items.push_condition(Condition::new("multiLineOrHangingCondition", ConditionProperties {
                 condition: Box::new(multi_line_or_hanging_condition_resolver.clone()),
                 true_path: {
-                    let mut items = Vec::new();
-                    items.push(PrintItem::NewLine);
-                    items.push(parsed_value.clone().into());
+                    let mut items = PrintItems::new();
+                    items.push_signal(Signal::NewLine);
+                    items.extend(parsed_value.clone());
                     Some(items.into())
                 },
                 false_path: {
-                    let mut items = Vec::new();
-                    items.push(PrintItem::SpaceOrNewLine);
-                    items.push(conditions::indent_if_start_of_line(parsed_value.into()).into());
+                    let mut items = PrintItems::new();
+                    items.push_signal(Signal::SpaceOrNewLine);
+                    items.push_condition(conditions::indent_if_start_of_line(parsed_value.into()));
                     Some(items.into())
                 },
-            }).into());
+            }));
         }
     }
 
-    return items.into();
+    return items;
 
-    fn parse_value<'a>(value: Node<'a>, has_comma: bool, context: &mut Context<'a>) -> PrintItem {
-        parser_helpers::new_line_group(parse_node_with_inner_parse(value, context, move |item| {
-            if has_comma {
-                vec![item, ",".into()].into()
-            } else {
-                item
-            }
+    fn parse_value<'a>(value: Node<'a>, has_comma: bool, context: &mut Context<'a>) -> PrintItems {
+        parser_helpers::new_line_group(parse_node_with_inner_parse(value, context, move |mut items| {
+            if has_comma { items.push_str(","); }
+            items
         })).into()
     }
 }
 
 /// For some reason, some nodes don't have a TsTypeAnn, but instead of a Box<TsType>
-fn parse_type_annotation_with_colon_if_exists_for_type<'a>(type_ann: &'a Option<Box<TsType>>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_type_annotation_with_colon_if_exists_for_type<'a>(type_ann: &'a Option<Box<TsType>>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if let Some(type_ann) = type_ann {
         if context.config.type_annotation_space_before_colon {
-            items.push(" ".into());
+            items.push_str(" ");
         }
-        items.push(parse_node_with_preceeding_colon(Some(type_ann.into()), context));
+        items.extend(parse_node_with_preceeding_colon(Some(type_ann.into()), context));
     }
-    items.into()
+    items
 }
 
-fn parse_type_annotation_with_colon_if_exists<'a>(type_ann: &'a Option<TsTypeAnn>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_type_annotation_with_colon_if_exists<'a>(type_ann: &'a Option<TsTypeAnn>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if let Some(type_ann) = type_ann {
         if context.config.type_annotation_space_before_colon {
-            items.push(" ".into());
+            items.push_str(" ");
         }
-        items.push(parse_node_with_preceeding_colon(Some(type_ann.into()), context));
+        items.extend(parse_node_with_preceeding_colon(Some(type_ann.into()), context));
     }
-    items.into()
+    items
 }
 
-fn parse_node_with_preceeding_colon<'a>(node: Option<Node<'a>>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_node_with_preceeding_colon<'a>(node: Option<Node<'a>>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if let Some(node) = node {
-        items.push(":".into());
-        items.push(PrintItem::SpaceOrNewLine);
-        items.push(conditions::indent_if_start_of_line(parse_node(node, context)).into());
+        items.push_str(":");
+        items.push_signal(Signal::SpaceOrNewLine);
+        items.push_condition(conditions::indent_if_start_of_line(parse_node(node, context)));
     }
-    items.into()
+    items
 }
 
 struct ParseBraceSeparatorOptions<'a> {
@@ -4191,7 +4138,7 @@ struct ParseBraceSeparatorOptions<'a> {
     start_header_info: Option<Info>,
 }
 
-fn parse_brace_separator<'a>(opts: ParseBraceSeparatorOptions<'a>, context: &mut Context) -> PrintItem {
+fn parse_brace_separator<'a>(opts: ParseBraceSeparatorOptions<'a>, context: &mut Context) -> PrintItems {
     match opts.brace_position {
         BracePosition::NextLineIfHanging => {
             if let Some(start_header_info) = opts.start_header_info {
@@ -4208,12 +4155,12 @@ fn parse_brace_separator<'a>(opts: ParseBraceSeparatorOptions<'a>, context: &mut
             " ".into()
         },
         BracePosition::NextLine => {
-            PrintItem::NewLine
+            Signal::NewLine.into()
         },
         BracePosition::Maintain => {
             if let Some(open_brace_token) = opts.open_brace_token {
                 if node_helpers::is_first_node_on_line(open_brace_token, context) {
-                    PrintItem::NewLine
+                    Signal::NewLine.into()
                 } else {
                     " ".into()
                 }
@@ -4224,7 +4171,7 @@ fn parse_brace_separator<'a>(opts: ParseBraceSeparatorOptions<'a>, context: &mut
     }
 }
 
-fn parse_node_in_parens<'a, F>(first_inner_node: Node<'a>, inner_parse_node: F, context: &mut Context<'a>) -> PrintItem where F : Fn(&mut Context<'a>) -> PrintItem {
+fn parse_node_in_parens<'a, F>(first_inner_node: Node<'a>, inner_parse_node: F, context: &mut Context<'a>) -> PrintItems where F : Fn(&mut Context<'a>) -> PrintItems {
     let open_paren_token = context.token_finder.get_previous_token_if_open_paren(&first_inner_node);
     let use_new_lines = {
         if let Some(open_paren_token) = &open_paren_token {
@@ -4243,46 +4190,46 @@ fn parse_node_in_parens<'a, F>(first_inner_node: Node<'a>, inner_parse_node: F, 
     return wrap_in_parens(inner_parse_node(context), use_new_lines);
 }
 
-fn wrap_in_parens(parsed_node: PrintItem, use_new_lines: bool) -> PrintItem {
+fn wrap_in_parens(parsed_node: PrintItems, use_new_lines: bool) -> PrintItems {
     parser_helpers::new_line_group({
-        let mut items = Vec::new();
-        items.push("(".into());
+        let mut items = PrintItems::new();
+        items.push_str("(");
         if use_new_lines {
-            items.push(PrintItem::NewLine);
-            items.push(parser_helpers::with_indent(parsed_node));
-            items.push(PrintItem::NewLine);
+            items.push_signal(Signal::NewLine);
+            items.extend(parser_helpers::with_indent(parsed_node));
+            items.push_signal(Signal::NewLine);
         } else {
-            items.push(parsed_node);
+            items.extend(parsed_node);
         }
-        items.push(")".into());
-        items.into()
+        items.push_str(")");
+        items
     })
 }
 
-fn parse_extends_or_implements<'a>(text: &'a str, type_items: Vec<Node<'a>>, start_header_info: Info, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_extends_or_implements<'a>(text: &'a str, type_items: Vec<Node<'a>>, start_header_info: Info, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
     if type_items.is_empty() {
-        return items.into();
+        return items;
     }
 
-    items.push(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_header_info, None).into());
+    items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_header_info, None));
     // the newline group will force it to put the extends or implements on a new line
-    items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group({
-        let mut items = Vec::new();
-        items.push(format!("{} ", text).into());
+    items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group({
+        let mut items = PrintItems::new();
+        items.push_str(&format!("{} ", text));
         for (i, type_item) in type_items.into_iter().enumerate() {
             if i > 0 {
-                items.push(",".into());
-                items.push(PrintItem::SpaceOrNewLine);
+                items.push_str(",");
+                items.push_signal(Signal::SpaceOrNewLine);
             }
 
-            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node(type_item, context))).into());
+            items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node(type_item, context))));
         }
-        items.into()
-    })).into());
+        items
+    })));
 
-    return items.into();
+    return items;
 }
 
 struct ParseObjectLikeNodeOptions<'a> {
@@ -4291,12 +4238,12 @@ struct ParseObjectLikeNodeOptions<'a> {
     trailing_commas: Option<TrailingCommas>,
 }
 
-fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
 
     if opts.members.is_empty() {
-        items.push("{}".into()); // todo: comments?
-        return items.into();
+        items.push_str("{}"); // todo: comments?
+        return items;
     }
 
     let open_brace_token = context.token_finder.get_first_open_brace_token_within(&opts.node_span).expect("Expected to find an open brace token.");
@@ -4306,13 +4253,13 @@ fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mu
         &opts.members[0],
         context
     );
-    let separator = if multi_line { PrintItem::NewLine } else { " ".into() }.into_rc();
+    let separator: PrintItems = if multi_line { Signal::NewLine.into() } else { " ".into() };
 
-    items.push("{".into());
-    items.push(separator.clone().into());
+    items.push_str("{");
+    items.extend(separator.clone());
 
     if multi_line {
-        items.push(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
+        items.extend(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
             inner_span: Span::new(open_brace_token.hi(), close_brace_token.lo(), Default::default()),
             items: opts.members.into_iter().map(|member| (member.into(), None)).collect(),
             should_use_space: None,
@@ -4323,27 +4270,24 @@ fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mu
     } else {
         let members_len = opts.members.len();
         for (i, member) in opts.members.into_iter().enumerate() {
-            if i > 0 { items.push(PrintItem::SpaceOrNewLine); }
+            if i > 0 { items.push_signal(Signal::SpaceOrNewLine); }
 
             let trailing_commas = opts.trailing_commas;
-            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node_with_inner_parse(member, context, move |item| {
+            items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node_with_inner_parse(member, context, move |mut items| {
                 if let Some(trailing_commas) = trailing_commas {
                     if i < members_len - 1 || get_force_trailing_commas(trailing_commas, multi_line) {
-                        vec![item, ",".into()].into()
-                    } else {
-                        item
+                        items.push_str(",");
                     }
-                } else {
-                    item
                 }
-            }))).into());
+                items
+            }))));
         }
     }
 
-    items.push(separator.into());
-    items.push("}".into());
+    items.extend(separator);
+    items.push_str("}");
 
-    return items.into();
+    return items;
 }
 
 struct MemberLikeExpr<'a> {
@@ -4352,34 +4296,34 @@ struct MemberLikeExpr<'a> {
     is_computed: bool,
 }
 
-fn parse_for_member_like_expr<'a>(node: MemberLikeExpr<'a>, context: &mut Context<'a>) -> PrintItem {
+fn parse_for_member_like_expr<'a>(node: MemberLikeExpr<'a>, context: &mut Context<'a>) -> PrintItems {
     let use_new_line = node_helpers::get_use_new_lines_for_nodes(&node.left_node, &node.right_node, context);
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
     let is_optional = context.parent().kind() == NodeKind::OptChainExpr;
 
-    items.push(parse_node(node.left_node, context));
-    items.push(if use_new_line { PrintItem::NewLine } else { PrintItem::PossibleNewLine });
-    items.push(conditions::indent_if_start_of_line({
-        let mut items = Vec::new();
+    items.extend(parse_node(node.left_node, context));
+    items.push_signal(if use_new_line { Signal::NewLine } else { Signal::PossibleNewLine });
+    items.push_condition(conditions::indent_if_start_of_line({
+        let mut items = PrintItems::new();
 
         if is_optional {
-            items.push("?".into());
-            if node.is_computed { items.push(".".into()); }
+            items.push_str("?");
+            if node.is_computed { items.push_str("."); }
         }
-        items.push(if node.is_computed { "[" } else { "." }.into());
-        items.push(parse_node(node.right_node, context));
-        if node.is_computed { items.push("]".into()); }
+        items.push_str(if node.is_computed { "[" } else { "." });
+        items.extend(parse_node(node.right_node, context));
+        if node.is_computed { items.push_str("]"); }
 
-        items.into()
-    }).into());
+        items
+    }));
 
-    return items.into();
+    return items;
 }
 
-fn parse_decorators<'a>(decorators: &'a Vec<Decorator>, is_inline: bool, context: &mut Context<'a>) -> PrintItem {
-    let mut items = Vec::new();
+fn parse_decorators<'a>(decorators: &'a Vec<Decorator>, is_inline: bool, context: &mut Context<'a>) -> PrintItems {
+    let mut items = PrintItems::new();
     if decorators.is_empty() {
-        return items.into();
+        return items;
     }
 
     let use_new_lines = !is_inline
@@ -4388,28 +4332,28 @@ fn parse_decorators<'a>(decorators: &'a Vec<Decorator>, is_inline: bool, context
 
     for (i, decorator) in decorators.iter().enumerate() {
         if i > 0 {
-            items.push(if use_new_lines {
-                PrintItem::NewLine
+            items.push_signal(if use_new_lines {
+                Signal::NewLine
             } else {
-                PrintItem::SpaceOrNewLine
+                Signal::SpaceOrNewLine
             });
         }
 
         let parsed_node = parse_node(decorator.into(), context);
         if is_inline {
-            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parsed_node)).into());
+            items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parsed_node)));
         } else {
-            items.push(parser_helpers::new_line_group(parsed_node));
+            items.extend(parser_helpers::new_line_group(parsed_node));
         }
     }
 
-    items.push(if is_inline {
-        PrintItem::SpaceOrNewLine
+    items.push_signal(if is_inline {
+        Signal::SpaceOrNewLine
     } else {
-        PrintItem::NewLine
+        Signal::NewLine
     });
 
-    return items.into();
+    return items;
 }
 
 fn parse_control_flow_separator(
@@ -4417,28 +4361,28 @@ fn parse_control_flow_separator(
     previous_node_block: &Span,
     token_text: &str,
     context: &mut Context
-) -> PrintItem {
-    let mut items = Vec::new();
+) -> PrintItems {
+    let mut items = PrintItems::new();
     match next_control_flow_position {
-        NextControlFlowPosition::SameLine => items.push(" ".into()),
-        NextControlFlowPosition::NextLine => items.push(PrintItem::NewLine),
+        NextControlFlowPosition::SameLine => items.push_str(" "),
+        NextControlFlowPosition::NextLine => items.push_signal(Signal::NewLine),
         NextControlFlowPosition::Maintain => {
             let token = context.token_finder.get_first_keyword_after(&previous_node_block, token_text);
 
             if token.is_some() && node_helpers::is_first_node_on_line(&token.unwrap(), context) {
-                items.push(PrintItem::NewLine);
+                items.push_signal(Signal::NewLine);
             } else {
-                items.push(" ".into());
+                items.push_str(" ");
             }
         }
     }
-    return items.into();
+    return items;
 }
 
 struct ParseHeaderWithConditionalBraceBodyOptions<'a> {
     parent: &'a Span,
     body_node: Node<'a>,
-    parsed_header: PrintItem,
+    parsed_header: PrintItems,
     use_braces: UseBraces,
     brace_position: BracePosition,
     single_body_position: Option<SingleBodyPosition>,
@@ -4446,18 +4390,18 @@ struct ParseHeaderWithConditionalBraceBodyOptions<'a> {
 }
 
 struct ParseHeaderWithConditionalBraceBodyResult {
-    parsed_node: PrintItem,
+    parsed_node: PrintItems,
     open_brace_condition: Condition,
 }
 
 fn parse_header_with_conditional_brace_body<'a>(opts: ParseHeaderWithConditionalBraceBodyOptions<'a>, context: &mut Context<'a>) -> ParseHeaderWithConditionalBraceBodyResult {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
 
-    items.push(start_header_info.clone().into());
-    items.push(opts.parsed_header);
-    items.push(end_header_info.clone().into());
+    items.push_info(start_header_info.clone());
+    items.extend(opts.parsed_header);
+    items.push_info(end_header_info.clone());
     let result = parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: opts.parent,
         body_node: opts.body_node,
@@ -4469,11 +4413,11 @@ fn parse_header_with_conditional_brace_body<'a>(opts: ParseHeaderWithConditional
         start_header_info: Some(start_header_info),
         end_header_info: Some(end_header_info),
     }, context);
-    items.push(result.parsed_node);
+    items.extend(result.parsed_node);
 
     return ParseHeaderWithConditionalBraceBodyResult {
         open_brace_condition: result.open_brace_condition,
-        parsed_node: items.into(),
+        parsed_node: items,
     };
 }
 
@@ -4490,7 +4434,7 @@ struct ParseConditionalBraceBodyOptions<'a> {
 }
 
 struct ParseConditionalBraceBodyResult {
-    parsed_node: PrintItem,
+    parsed_node: PrintItems,
     open_brace_condition: Condition,
 }
 
@@ -4529,7 +4473,7 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
                 return Some(resolved_end_statements_info.line_number > resolved_start_info.line_number);
             })
         },
-        true_path: Some(PrintItem::NewLine),
+        true_path: Some(Signal::NewLine.into()),
         false_path: Some(" ".into()),
     });
     let open_brace_condition = Condition::new("openBrace", ConditionProperties {
@@ -4576,59 +4520,57 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
             })
         },
         true_path: {
-            let mut items = Vec::new();
-            items.push(parse_brace_separator(ParseBraceSeparatorOptions {
+            let mut items = PrintItems::new();
+            items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
                 brace_position: opts.brace_position,
                 open_brace_token: open_brace_token,
                 start_header_info: start_header_info.clone(),
             }, context));
-            items.push("{".into());
+            items.push_str("{");
             Some(items.into())
         },
         false_path: None,
     });
 
     // parse body
-    let mut items = Vec::new();
-    items.push(open_brace_condition.clone().into());
-    if let Some(parsed_comments) = parse_comment_collection(header_trailing_comments.into_iter(), None, context) {
-        items.push(" ".into());
-        items.push(parsed_comments);
+    let mut items = PrintItems::new();
+    items.push_condition(open_brace_condition.clone());
+    let parsed_comments = parse_comment_collection(header_trailing_comments.into_iter(), None, context);
+    if !parsed_comments.is_empty() {
+        items.push_str(" ");
+        items.extend(parsed_comments);
     }
-    items.push(newline_or_space_condition.clone().into());
-    items.push(start_statements_info.clone().into());
+    items.push_condition(newline_or_space_condition.clone());
+    items.push_info(start_statements_info.clone());
 
     if let Node::BlockStmt(body_node) = opts.body_node {
-        items.push(parser_helpers::with_indent({
-            let mut items = Vec::new();
+        items.extend(parser_helpers::with_indent({
+            let mut items = PrintItems::new();
             // parse the remaining trailing comments inside because some of them are parsed already
             // by parsing the header trailing comments
-            if let Some(parsed_comments) = parse_leading_comments(&body_node, context) {
-                items.push(parsed_comments);
-            }
-            items.push(parse_statements(body_node.get_inner_span(context), body_node.stmts.iter().map(|x| x.into()).collect(), context));
-            items.into()
+            items.extend(parse_leading_comments(&body_node, context));
+            items.extend(parse_statements(body_node.get_inner_span(context), body_node.stmts.iter().map(|x| x.into()).collect(), context));
+            items
         }));
     } else {
-        items.push(parser_helpers::with_indent({
-            let mut items = Vec::new();
+        items.extend(parser_helpers::with_indent({
+            let mut items = PrintItems::new();
             let body_node_span = opts.body_node.span();
-            items.push(parse_node(opts.body_node, context));
-            if let Some(parsed_comments) = parse_trailing_comments(&body_node_span, context) {
-                items.push(parsed_comments);
-            }
-            items.into()
+            items.extend(parse_node(opts.body_node, context));
+            items.extend(parse_trailing_comments(&body_node_span, context));
+            items
         }));
     }
 
-    items.push(end_statements_info.clone().into());
-    items.push(Condition::new("closeBrace", ConditionProperties {
+    items.push_info(end_statements_info.clone());
+    items.push_condition(Condition::new("closeBrace", ConditionProperties {
         condition: {
             let open_brace_condition = open_brace_condition.clone();
             Box::new(move |condition_context| condition_context.get_resolved_condition(&open_brace_condition))
         },
-        true_path: Some(vec![
-            Condition::new("closeBraceNewLine", ConditionProperties {
+        true_path: Some({
+            let mut items = PrintItems::new();
+            items.push_condition(Condition::new("closeBraceNewLine", ConditionProperties {
                 condition: {
                     let newline_or_space_condition = newline_or_space_condition.clone();
                     Box::new(move |condition_context| {
@@ -4638,7 +4580,7 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
                         return Some(!are_infos_equal);
                     })
                 },
-                true_path: Some(PrintItem::NewLine),
+                true_path: Some(Signal::NewLine.into()),
                 false_path: Some(Condition::new("closeBraceSpace", ConditionProperties {
                     condition: Box::new(move |condition_context| {
                         let is_new_line = condition_context.get_resolved_condition(&newline_or_space_condition)?;
@@ -4647,11 +4589,12 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
                     true_path: Some(" ".into()),
                     false_path: None,
                 }).into())
-            }).into(),
-            "}".into()
-        ].into()),
+            }));
+            items.push_str("}");
+            items
+        }),
         false_path: None,
-    }).into());
+    }));
 
     // return result
     return ParseConditionalBraceBodyResult {
@@ -4760,7 +4703,7 @@ struct ParseJsxWithOpeningAndClosingOptions<'a> {
     children: Vec<Node<'a>>,
 }
 
-fn parse_jsx_with_opening_and_closing<'a>(opts: ParseJsxWithOpeningAndClosingOptions<'a>, context: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_with_opening_and_closing<'a>(opts: ParseJsxWithOpeningAndClosingOptions<'a>, context: &mut Context<'a>) -> PrintItems {
     let use_multi_lines = get_use_multi_lines(&opts.opening_element, &opts.children, context);
     let children = opts.children.into_iter().filter(|c| match c {
         Node::JSXText(c) => !c.text(context).trim().is_empty(),
@@ -4768,22 +4711,22 @@ fn parse_jsx_with_opening_and_closing<'a>(opts: ParseJsxWithOpeningAndClosingOpt
     }).collect();
     let start_info = Info::new("startInfo");
     let end_info = Info::new("endInfo");
-    let mut items = Vec::new();
+    let mut items = PrintItems::new();
     let inner_span = Span::new(opts.opening_element.span().hi(), opts.closing_element.span().lo(), Default::default());
 
-    items.push(start_info.clone().into());
-    items.push(parse_node(opts.opening_element, context));
-    items.push(parse_jsx_children(ParseJsxChildrenOptions {
+    items.push_info(start_info.clone());
+    items.extend(parse_node(opts.opening_element, context));
+    items.extend(parse_jsx_children(ParseJsxChildrenOptions {
         inner_span,
         children,
         parent_start_info: start_info,
         parent_end_info: end_info.clone(),
         use_multi_lines,
     }, context));
-    items.push(parse_node(opts.closing_element, context));
-    items.push(end_info.into());
+    items.extend(parse_node(opts.closing_element, context));
+    items.push_info(end_info);
 
-    return items.into();
+    return items;
 
     fn get_use_multi_lines(opening_element: &Node, children: &Vec<Node>, context: &mut Context) -> bool {
         if let Some(first_child) = children.get(0) {
@@ -4808,11 +4751,11 @@ struct ParseJsxChildrenOptions<'a> {
     use_multi_lines: bool,
 }
 
-fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Context<'a>) -> PrintItem {
+fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Context<'a>) -> PrintItems {
     // Need to parse the children here so they only get parsed once.
     // Nodes need to be only parsed once so that their comments don't end up in
     // the handled comments collection and the second time they won't be parsed out.
-    let children = opts.children.into_iter().map(|c| (c.clone(), parse_node(c, context).into_rc())).collect();
+    let children = opts.children.into_iter().map(|c| (c.clone(), parse_node(c, context))).collect();
     let parent_start_info = opts.parent_start_info;
     let parent_end_info = opts.parent_end_info;
 
@@ -4837,11 +4780,11 @@ fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Conte
         }).into();
     }
 
-    fn parse_for_new_lines<'a>(children: Vec<(Node<'a>, Rc<PrintItem>)>, inner_span: Span, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn parse_for_new_lines<'a>(children: Vec<(Node<'a>, PrintItems)>, inner_span: Span, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
         let has_children = !children.is_empty();
-        items.push(PrintItem::NewLine);
-        items.push(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
+        items.push_signal(Signal::NewLine);
+        items.extend(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
             inner_span,
             items: children.into_iter().map(|(a, b)| (a, Some(b.into()))).collect(),
             should_use_space: Some(Box::new(|previous, next, context| should_use_space(previous, next, context))),
@@ -4867,31 +4810,31 @@ fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Conte
         }, context)));
 
         if has_children {
-            items.push(PrintItem::NewLine);
+            items.push_signal(Signal::NewLine);
         }
 
-        return items.into();
+        return items;
     }
 
-    fn parse_for_single_line<'a>(children: Vec<(Node<'a>, Rc<PrintItem>)>, context: &mut Context<'a>) -> PrintItem {
-        let mut items = Vec::new();
+    fn parse_for_single_line<'a>(children: Vec<(Node<'a>, PrintItems)>, context: &mut Context<'a>) -> PrintItems {
+        let mut items = PrintItems::new();
         if children.is_empty() {
-            items.push(PrintItem::PossibleNewLine);
+            items.push_signal(Signal::PossibleNewLine);
         } else {
             let mut previous_child: Option<Node<'a>> = None;
             for (child, parsed_child) in children.into_iter() {
                 if let Some(previous_child) = previous_child {
                     if should_use_space(&previous_child, &child, context) {
-                        items.push(PrintItem::SpaceOrNewLine);
+                        items.push_signal(Signal::SpaceOrNewLine);
                     }
                 }
 
-                items.push(parsed_child.into());
-                items.push(PrintItem::PossibleNewLine);
+                items.extend(parsed_child);
+                items.push_signal(Signal::PossibleNewLine);
                 previous_child = Some(child);
             }
         }
-        return items.into();
+        return items;
     }
 
     fn should_use_space(previous_element: &Node, next_element: &Node, context: &mut Context) -> bool {

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -2608,7 +2608,7 @@ fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintIt
                 for item in PrintItemsIterator::new(path.clone()) {
                     match item {
                         PrintItem::String(value) => {
-                            if let Some(c) = value.chars().next() {
+                            if let Some(c) = value.text.chars().next() {
                                 return utils::is_prefix_semi_colon_insertion_char(c).into();
                             }
                         },

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -382,7 +382,7 @@ fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> P
     let end_header_info = Info::new("catchClauseHeaderEnd");
     let mut items = PrintItems::new();
 
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
     items.push_str("catch");
 
     if let Some(param) = &node.param {
@@ -390,7 +390,7 @@ fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> P
         items.extend(parse_node(param.into(), context));
         items.push_str(")");
     }
-    items.push_info(end_header_info.clone());
+    items.push_info(end_header_info);
 
     // not conditional... required
     items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
@@ -480,7 +480,7 @@ fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context
     let start_header_info = Info::new("startHeader");
     let parsed_header = {
         let mut items = PrintItems::new();
-        items.push_info(start_header_info.clone());
+        items.push_info(start_header_info);
 
         if node.is_declare { items.push_str("declare "); }
         if node.is_abstract { items.push_str("abstract "); }
@@ -495,7 +495,7 @@ fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context
             items.extend(parse_node(type_params, context));
         }
         if let Some(super_class) = node.super_class {
-            items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_header_info.clone(), None));
+            items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_header_info, None));
             items.push_condition(conditions::indent_if_start_of_line({
                 let mut items = PrintItems::new();
                 items.push_str("extends ");
@@ -506,7 +506,7 @@ fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context
                 items
             }));
         }
-        items.extend(parse_extends_or_implements("implements", node.implements, start_header_info.clone(), context));
+        items.extend(parse_extends_or_implements("implements", node.implements, start_header_info, context));
         items
     };
 
@@ -564,7 +564,7 @@ fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> Print
     let mut items = PrintItems::new();
 
     // header
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
 
     if node.declare { items.push_str("declare "); }
     if node.is_const { items.push_str("const "); }
@@ -678,7 +678,7 @@ fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &m
     let start_header_info = Info::new("functionHeaderStart");
     let func = node.func;
 
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
     if node.declare { items.push_str("declare "); }
     if func.is_async { items.push_str("async "); }
     items.push_str("function");
@@ -698,7 +698,7 @@ fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &m
             context.config.function_expression_force_multi_line_parameters
         },
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
-            start_info: start_header_info.clone(),
+            start_info: start_header_info,
             type_node: func.return_type.as_ref().map(|x| x.into()),
             type_node_separator: None,
         }, context)),
@@ -799,8 +799,8 @@ fn parse_import_equals_decl<'a>(node: &'a TsImportEqualsDecl, context: &mut Cont
 fn parse_interface_decl<'a>(node: &'a TsInterfaceDecl, context: &mut Context<'a>) -> PrintItems {
     let mut items = PrintItems::new();
     let start_header_info = Info::new("startHeader");
-    items.push_info(start_header_info.clone());
-    context.store_info_for_node(&node, start_header_info.clone());
+    items.push_info(start_header_info);
+    context.store_info_for_node(&node, start_header_info);
 
     if node.declare { items.push_str("declare "); }
     items.push_str("interface ");
@@ -844,7 +844,7 @@ fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: 
     let mut items = PrintItems::new();
 
     let start_header_info = Info::new("startHeader");
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
 
     if node.declare { items.push_str("declare "); }
     if node.global {
@@ -975,7 +975,7 @@ fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> 
     let header_start_info = Info::new("arrowFunctionExpressionHeaderStart");
     let should_use_params = get_should_use_params(&node, context);
 
-    items.push_info(header_start_info.clone());
+    items.push_info(header_start_info);
     if node.is_async { items.push_str("async "); }
     if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
 
@@ -984,7 +984,7 @@ fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> 
             nodes: node.params.iter().map(|node| node.into()).collect(),
             force_multi_line_when_multiple_lines: context.config.arrow_function_expression_force_multi_line_parameters,
             custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
-                start_info: header_start_info.clone(),
+                start_info: header_start_info,
                 type_node: node.return_type.as_ref().map(|x| x.into()),
                 type_node_separator: None,
             }, context)),
@@ -1093,7 +1093,7 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
         let mut items = PrintItems::new();
 
         if is_top_most {
-            items.push_info(top_most_info.clone());
+            items.push_info(top_most_info);
         }
 
         let node_left_node = Node::from(node_left);
@@ -1101,7 +1101,7 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
             context.mark_disable_indent_for_next_bin_expr();
         }
 
-        items.extend(indent_if_necessary(node_left.lo(), top_most_expr_start, top_most_info.clone(), indent_disabled, {
+        items.extend(indent_if_necessary(node_left.lo(), top_most_expr_start, top_most_info, indent_disabled, {
             new_line_group_if_necessary(&node_left, parse_node_with_inner_parse(node_left_node, context, move |mut items| {
                 if operator_position == OperatorPosition::SameLine {
                     if use_space_surrounding_operator {
@@ -1187,10 +1187,10 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintI
     fn get_or_set_top_most_info(top_most_expr_start: BytePos, is_top_most: bool, context: &mut Context) -> Info {
         if is_top_most {
             let info = Info::new("topBinaryOrLogicalExpressionStart");
-            context.store_info_for_node(&top_most_expr_start, info.clone());
+            context.store_info_for_node(&top_most_expr_start, info);
             return info;
         }
-        return context.get_info_for_node(&top_most_expr_start).expect("Expected to have the top most expr info stored").clone();
+        return context.get_info_for_node(&top_most_expr_start).expect("Expected to have the top most expr info stored");
     }
 
     fn get_top_most_binary_expr_pos(node: &BinExpr, context: &mut Context) -> BytePos {
@@ -1401,7 +1401,7 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
     let end_info = Info::new("endConditionalExpression");
     let mut items = PrintItems::new();
 
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
     items.extend(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.test).into(), context, {
         move |mut items| {
             if operator_position == OperatorPosition::SameLine {
@@ -1412,12 +1412,12 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
     })));
 
     // force re-evaluation of all the conditions below once the end info has been reached
-    items.push_condition(conditions::force_reevaluation_once_resolved(context.end_statement_or_member_infos.peek().unwrap_or(&end_info).clone()));
+    items.push_condition(conditions::force_reevaluation_once_resolved(context.end_statement_or_member_infos.peek().map(|x| x.clone()).unwrap_or(end_info)));
 
     if use_new_lines {
         items.push_signal(Signal::NewLine);
     } else {
-        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info.clone(), Some(before_alternate_info.clone())));
+        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(before_alternate_info)));
     }
 
     items.push_condition(conditions::indent_if_start_of_line({
@@ -1439,7 +1439,7 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
     if use_new_lines {
         items.push_signal(Signal::NewLine);
     } else {
-        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(before_alternate_info.clone())));
+        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(before_alternate_info)));
     }
 
     items.push_condition(conditions::indent_if_start_of_line({
@@ -1489,7 +1489,7 @@ fn parse_expr_with_type_args<'a>(node: &'a TsExprWithTypeArgs, context: &mut Con
 fn parse_fn_expr<'a>(node: &'a FnExpr, context: &mut Context<'a>) -> PrintItems {
     parse_function_decl_or_expr(FunctionDeclOrExprNode {
         is_func_decl: false,
-        ident: node.ident.as_ref().clone(),
+        ident: node.ident.as_ref(),
         declare: false,
         func: &node.function,
     }, context)
@@ -1806,7 +1806,7 @@ fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Co
     let mut items = PrintItems::new();
     let start_info = Info::new("startCallSignature");
 
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
     if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
     items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
@@ -1826,7 +1826,7 @@ fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, contex
     let mut items = PrintItems::new();
     let start_info = Info::new("startConstructSignature");
 
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
     items.push_str("new");
     if context.config.construct_signature_space_after_new_keyword { items.push_str(" "); }
     if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
@@ -1886,7 +1886,7 @@ fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>
 fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context<'a>) -> PrintItems {
     let mut items = PrintItems::new();
     let start_info = Info::new("startMethodSignature");
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
 
     if node.computed { items.push_str("["); }
     items.extend(parse_node((&node.key).into(), context));
@@ -2040,7 +2040,7 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
     let start_info = Info::new("openingElementStartInfo");
     let mut items = PrintItems::new();
 
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
     items.push_str("<");
     items.extend(parse_node((&node.name).into(), context));
     if let Some(type_args) = &node.type_args {
@@ -2341,7 +2341,7 @@ fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut
     }
 
     let start_header_info = Info::new("methodStartHeaderInfo");
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
 
     if let Some(accessibility) = node.accessibility {
         items.push_str(&format!("{} ", accessibility_to_str(&accessibility)));
@@ -2366,7 +2366,7 @@ fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut
         nodes: node.params.into_iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: get_force_multi_line_parameters(&node.kind, context),
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
-            start_info: start_header_info.clone(),
+            start_info: start_header_info,
             type_node: node.return_type,
             type_node_separator: None,
         }, context)),
@@ -2451,11 +2451,11 @@ fn parse_block_stmt<'a>(node: &'a BlockStmt, context: &mut Context<'a>) -> Print
 
     items.extend(parse_first_line_trailing_comments(&node, node.stmts.get(0).map(|x| x as &dyn Spanned), context));
     items.push_signal(Signal::NewLine);
-    items.push_info(start_statements_info.clone());
+    items.push_info(start_statements_info);
     items.extend(parser_helpers::with_indent(
         parse_statements(node.get_inner_span(context), node.stmts.iter().map(|stmt| stmt.into()).collect(), context)
     ));
-    items.push_info(end_statements_info.clone());
+    items.push_info(end_statements_info);
     items.push_condition(Condition::new("endStatementsNewLine", ConditionProperties {
         condition: Box::new(move |context| {
             condition_resolvers::are_infos_equal(context, &start_statements_info, &end_statements_info)
@@ -2639,7 +2639,7 @@ fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> PrintItem
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
     let mut items = PrintItems::new();
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
     items.push_str("for");
     if context.config.for_statement_space_after_for_keyword {
         items.push_str(" ");
@@ -2676,7 +2676,7 @@ fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> PrintItem
         }
         items
     }, context));
-    items.push_info(end_header_info.clone());
+    items.push_info(end_header_info);
 
     items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
@@ -2697,7 +2697,7 @@ fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> Prin
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
     let mut items = PrintItems::new();
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
     items.push_str("for");
     if context.config.for_in_statement_space_after_for_keyword {
         items.push_str(" ");
@@ -2714,7 +2714,7 @@ fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> Prin
         }));
         items
     }, context));
-    items.push_info(end_header_info.clone());
+    items.push_info(end_header_info);
 
     items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
@@ -2735,7 +2735,7 @@ fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> Prin
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
     let mut items = PrintItems::new();
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
     items.push_str("for");
     if context.config.for_of_statement_space_after_for_keyword {
         items.push_str(" ");
@@ -2756,7 +2756,7 @@ fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> Prin
         }));
         items
     }, context));
-    items.push_info(end_header_info.clone());
+    items.push_info(end_header_info);
 
     items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
@@ -2811,7 +2811,7 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> PrintItems 
         items.extend(parse_leading_comments(&alt, context));
 
         let start_else_header_info = Info::new("startElseHeader");
-        items.push_info(start_else_header_info.clone());
+        items.push_info(start_else_header_info);
         items.push_str("else");
 
         if let Stmt::If(alt) = &**alt {
@@ -2866,7 +2866,7 @@ fn parse_return_stmt<'a>(node: &'a ReturnStmt, context: &mut Context<'a>) -> Pri
 fn parse_switch_stmt<'a>(node: &'a SwitchStmt, context: &mut Context<'a>) -> PrintItems {
     let start_header_info = Info::new("startHeader");
     let mut items = PrintItems::new();
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
     items.push_str("switch ");
     items.extend(parse_node_in_parens((&node.discriminant).into(), |context| parse_node((&node.discriminant).into(), context), context));
     items.extend(parse_membered_body(ParseMemberedBodyOptions {
@@ -2890,7 +2890,7 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Pri
         node.span.lo()
     }).expect("Expected to find a colon token.");
 
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
 
     if let Some(test) = &node.test {
         items.push_str("case ");
@@ -3057,13 +3057,13 @@ fn parse_while_stmt<'a>(node: &'a WhileStmt, context: &mut Context<'a>) -> Print
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
     let mut items = PrintItems::new();
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
     items.push_str("while");
     if context.config.while_statement_space_after_while_keyword {
         items.push_str(" ");
     }
     items.extend(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
-    items.push_info(end_header_info.clone());
+    items.push_info(end_header_info);
     items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
@@ -3131,7 +3131,7 @@ fn parse_conditional_type<'a>(node: &'a TsConditionalType, context: &mut Context
 fn parse_constructor_type<'a>(node: &'a TsConstructorType, context: &mut Context<'a>) -> PrintItems {
     let start_info = Info::new("startConstructorType");
     let mut items = PrintItems::new();
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
     items.push_str("new");
     if context.config.constructor_type_space_after_new_keyword { items.push_str(" "); }
     if let Some(type_params) = &node.type_params {
@@ -3157,7 +3157,7 @@ fn parse_constructor_type<'a>(node: &'a TsConstructorType, context: &mut Context
 fn parse_function_type<'a>(node: &'a TsFnType, context: &mut Context<'a>) -> PrintItems {
     let start_info = Info::new("startFunctionType");
     let mut items = PrintItems::new();
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
     if let Some(type_params) = &node.type_params {
         items.extend(parse_node(type_params.into(), context));
     }
@@ -3229,12 +3229,12 @@ fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> P
     let end_info = Info::new("endMappedType");
     let open_brace_token = context.token_finder.get_first_open_brace_token_within(&node).expect("Expected to find an open brace token in the mapped type.");
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&open_brace_token, &node.type_param, context);
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
     items.push_str("{");
     if use_new_lines {
         items.push_signal(Signal::NewLine);
     } else {
-        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info.clone(), Some(end_info.clone())));
+        items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(end_info)));
     }
     items.push_condition(conditions::indent_if_start_of_line(parser_helpers::new_line_group({
         let mut items = PrintItems::new();
@@ -3261,7 +3261,7 @@ fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> P
         }
         items
     })));
-    items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(end_info.clone())));
+    items.push_condition(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(end_info)));
     items.push_str("}");
     items.push_info(end_info);
     return items;
@@ -3462,7 +3462,7 @@ fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, conte
             let after_separator_info = Info::new("afterSeparatorInfo");
             if i > 0 {
                 items.push_str(separator);
-                items.push_info(after_separator_info.clone());
+                items.push_info(after_separator_info);
             }
             if let Some(separator_token) = separator_token {
                 items.extend(parse_trailing_comments(&separator_token, context));
@@ -3898,7 +3898,7 @@ fn parse_statements_or_members<'a, FShouldUseBlankLine>(
         }
 
         let end_info = Info::new("endStatementOrMemberInfo");
-        context.end_statement_or_member_infos.push(end_info.clone());
+        context.end_statement_or_member_infos.push(end_info);
         items.extend(if let Some(print_items) = optional_print_items {
             print_items
         } else {
@@ -3955,23 +3955,19 @@ fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>
     let use_new_lines = get_use_new_lines(&nodes, context);
     let force_multi_lines_when_multiple_lines = opts.force_multi_line_when_multiple_lines;
     let is_single_function = nodes.len() == 1 && is_function_or_arrow_expr(&nodes[0]);
-    let is_multi_line_or_hanging = {
-        let start_info = start_info.clone(); // create copies
-        let end_info = end_info.clone();
-        move |condition_context: &mut ConditionResolverContext| {
-            if use_new_lines { return Some(true); }
-            if force_multi_lines_when_multiple_lines && !is_single_function {
-                return condition_resolvers::is_multiple_lines(condition_context, &start_info, &end_info);
-            }
-            return Some(false);
+    let is_multi_line_or_hanging = move |condition_context: &mut ConditionResolverContext| {
+        if use_new_lines { return Some(true); }
+        if force_multi_lines_when_multiple_lines && !is_single_function {
+            return condition_resolvers::is_multiple_lines(condition_context, &start_info, &end_info);
         }
+        return Some(false);
     };
 
     let mut items = PrintItems::new();
     items.push_info(start_info);
     items.push_str("(");
 
-    let param_list = parse_comma_separated_values(nodes, is_multi_line_or_hanging.clone(), context).into_rc_path();
+    let param_list = parse_comma_separated_values(nodes, is_multi_line_or_hanging, context).into_rc_path();
     items.push_condition(Condition::new("multiLineOrHanging", ConditionProperties {
         condition: Box::new(is_multi_line_or_hanging),
         true_path: Some(surround_with_new_lines(with_indent(param_list.clone().into()))),
@@ -4018,7 +4014,7 @@ fn parse_close_paren_with_type<'a>(opts: ParseCloseParenWithTypeOptions<'a>, con
     let has_type_node = opts.type_node.is_some();
     let type_node_end_info = Info::new("typeNodeEnd");
     let start_info = opts.start_info;
-    let parsed_type_node = parse_type_node(opts.type_node, opts.type_node_separator, type_node_start_info.clone(), type_node_end_info.clone(), context);
+    let parsed_type_node = parse_type_node(opts.type_node, opts.type_node_separator, type_node_start_info, type_node_end_info, context);
     let mut items = PrintItems::new();
 
     items.push_condition(Condition::new("newLineIfHeaderHangingAndTypeNodeMultipleLines", ConditionProperties {
@@ -4407,9 +4403,9 @@ fn parse_header_with_conditional_brace_body<'a>(opts: ParseHeaderWithConditional
     let end_header_info = Info::new("endHeader");
     let mut items = PrintItems::new();
 
-    items.push_info(start_header_info.clone());
+    items.push_info(start_header_info);
     items.extend(opts.parsed_header);
-    items.push_info(end_header_info.clone());
+    items.push_info(end_header_info);
     let result = parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: opts.parent,
         body_node: opts.body_node,
@@ -4465,32 +4461,24 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
     let open_brace_token = get_open_brace_token(&opts.body_node, context);
     let use_braces = opts.use_braces;
     let mut newline_or_space_condition = Condition::new("newLineOrSpace", ConditionProperties {
-        condition: {
-            let start_header_info = start_header_info.clone();
-            let end_statements_info = end_statements_info.clone();
-            Box::new(move |condition_context| {
-                if should_use_new_line {
-                    return Some(true);
-                }
-                let start_header_info = start_header_info.as_ref()?;
-                let resolved_start_info = condition_context.get_resolved_info(start_header_info)?;
-                if resolved_start_info.line_number < condition_context.writer_info.line_number {
-                    return Some(true);
-                }
-                let resolved_end_statements_info = condition_context.get_resolved_info(&end_statements_info)?;
-                return Some(resolved_end_statements_info.line_number > resolved_start_info.line_number);
-            })
-        },
+        condition: Box::new(move |condition_context| {
+            if should_use_new_line {
+                return Some(true);
+            }
+            let start_header_info = start_header_info.as_ref()?;
+            let resolved_start_info = condition_context.get_resolved_info(start_header_info)?;
+            if resolved_start_info.line_number < condition_context.writer_info.line_number {
+                return Some(true);
+            }
+            let resolved_end_statements_info = condition_context.get_resolved_info(&end_statements_info)?;
+            return Some(resolved_end_statements_info.line_number > resolved_start_info.line_number);
+        }),
         true_path: Some(Signal::NewLine.into()),
         false_path: Some(" ".into()),
     });
     let newline_or_space_condition_ref = newline_or_space_condition.get_reference();
     let mut open_brace_condition = Condition::new("openBrace", ConditionProperties {
         condition: {
-            let start_header_info = start_header_info.clone();
-            let end_header_info = end_header_info.clone();
-            let start_statements_info = start_statements_info.clone();
-            let end_statements_info = end_statements_info.clone();
             let has_open_brace_token = open_brace_token.is_some();
             Box::new(move |condition_context| {
                 match use_braces {
@@ -4532,7 +4520,7 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
             items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
                 brace_position: opts.brace_position,
                 open_brace_token: open_brace_token,
-                start_header_info: start_header_info.clone(),
+                start_header_info,
             }, context));
             items.push_str("{");
             Some(items)
@@ -4550,7 +4538,7 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
         items.extend(parsed_comments);
     }
     items.push_condition(newline_or_space_condition);
-    items.push_info(start_statements_info.clone());
+    items.push_info(start_statements_info);
 
     if let Node::BlockStmt(body_node) = opts.body_node {
         items.extend(parser_helpers::with_indent({
@@ -4571,7 +4559,7 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
         }));
     }
 
-    items.push_info(end_statements_info.clone());
+    items.push_info(end_statements_info);
     items.push_condition(Condition::new("closeBrace", ConditionProperties {
         condition: Box::new(move |condition_context| condition_context.get_resolved_condition(&open_brace_condition_ref)),
         true_path: Some({
@@ -4717,13 +4705,13 @@ fn parse_jsx_with_opening_and_closing<'a>(opts: ParseJsxWithOpeningAndClosingOpt
     let mut items = PrintItems::new();
     let inner_span = Span::new(opts.opening_element.span().hi(), opts.closing_element.span().lo(), Default::default());
 
-    items.push_info(start_info.clone());
+    items.push_info(start_info);
     items.extend(parse_node(opts.opening_element, context));
     items.extend(parse_jsx_children(ParseJsxChildrenOptions {
         inner_span,
         children,
         parent_start_info: start_info,
-        parent_end_info: end_info.clone(),
+        parent_end_info: end_info,
         use_multi_lines,
     }, context));
     items.extend(parse_node(opts.closing_element, context));

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -1319,7 +1319,7 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintIt
             let mut items = PrintItems::new();
             for item in old_items.iter() {
                 match item {
-                    PrintItem::String(_) | PrintItem::Condition(_) | PrintItem::Info(_) | PrintItem::RcPath(_) => items.push(item),
+                    PrintItem::String(_) | PrintItem::Condition(_) | PrintItem::Info(_) | PrintItem::RcPath(_) => items.push_item(item),
                     PrintItem::Signal(_) => {},
                 }
             }

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -1283,7 +1283,6 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintIt
 
         fn parse_test_library_callee<'a>(callee: &'a ExprOrSuper, context: &mut Context<'a>) -> PrintItems {
             match callee {
-                // todo: use box pattern matching once supported in rust stable
                 ExprOrSuper::Expr(expr) => {
                     let expr = &**expr;
                     match expr {
@@ -1317,7 +1316,6 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintIt
         }
 
         pub fn filter_signals(old_items: PrintItems) -> PrintItems {
-            // todo: add a Signal::StartIgnoringSignals and Signal::FinishIgnoringSignals
             let mut items = PrintItems::new();
             for item in old_items.iter() {
                 match item {
@@ -2053,12 +2051,7 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
         }
         items.push_str("/");
     } else {
-        // todo: move condition to core library
-        items.push_condition(Condition::new("newlineIfHanging", ConditionProperties {
-            condition: Box::new(move |condition_context| condition_resolvers::is_hanging(condition_context, &start_info, &None)),
-            true_path: Some(Signal::NewLine.into()),
-            false_path: None,
-        }));
+        items.push_condition(conditions::new_line_if_hanging(start_info, None));
     }
     items.push_str(">");
 

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -10,7 +10,7 @@ use swc_ecma_parser::{token::{TokenAndSpan}};
 
 // todo: Remove putting functions on heap by using type parameters?
 
-pub fn parse(source_file: ParsedSourceFile, config: TypeScriptConfiguration) -> Vec<PrintItem> {
+pub fn parse(source_file: ParsedSourceFile, config: TypeScriptConfiguration) -> PrintItem {
     let module = Node::Module(&source_file.module);
     let mut context = Context::new(
         config,
@@ -21,20 +21,21 @@ pub fn parse(source_file: ParsedSourceFile, config: TypeScriptConfiguration) -> 
         module,
         source_file.info
     );
-    let mut items = parse_node(Node::Module(&source_file.module), &mut context);
+    let mut items = Vec::new();
+    items.push(parse_node(Node::Module(&source_file.module), &mut context));
     items.push(if_true(
         "endOfFileNewLine",
         |context| Some(context.writer_info.column_number > 0 || context.writer_info.line_number > 0),
         PrintItem::NewLine
     ));
-    items
+    items.into()
 }
 
-fn parse_node<'a>(node: Node<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_node<'a>(node: Node<'a>, context: &mut Context<'a>) -> PrintItem {
     parse_node_with_inner_parse(node, context, |items| items)
 }
 
-fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, inner_parse: impl Fn(Vec<PrintItem>) -> Vec<PrintItem> + Clone + 'static) -> Vec<PrintItem> {
+fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, inner_parse: impl Fn(PrintItem) -> PrintItem + Clone + 'static) -> PrintItem {
     let mut items = Vec::new();
 
     // println!("Node kind: {:?}", node.kind());
@@ -52,9 +53,11 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
     let leading_comments = context.comments.leading_comments_with_previous(node_lo);
     let has_ignore_comment = get_has_ignore_comment(&leading_comments, &node_lo, context);
 
-    items.extend(parse_comments_as_leading(&node_span, leading_comments, context));
+    if let Some(parsed_comments) = parse_comments_as_leading(&node_span, leading_comments, context) {
+        items.push(parsed_comments);
+    }
 
-    items.extend(if has_ignore_comment {
+    items.push(if has_ignore_comment {
         parser_helpers::parse_raw_string(&node.text(context))
     } else {
         inner_parse(parse_node_inner(node, context))
@@ -62,15 +65,17 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
 
     if node_hi != parent_hi || context.parent().kind() == NodeKind::Module {
         let trailing_comments = context.comments.trailing_comments_with_previous(node_hi);
-        items.extend(parse_comments_as_trailing(&node_span, trailing_comments, context));
+        if let Some(parsed_comments) = parse_comments_as_trailing(&node_span, trailing_comments, context) {
+            items.push(parsed_comments);
+        }
     }
 
     // pop info
     context.current_node = context.parent_stack.pop();
 
-    return items;
+    return items.into();
 
-    fn parse_node_inner<'a>(node: Node<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_node_inner<'a>(node: Node<'a>, context: &mut Context<'a>) -> PrintItem {
         match node {
             /* class */
             Node::ClassMethod(node) => parse_class_method(node, context),
@@ -120,7 +125,7 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
             Node::SeqExpr(node) => parse_sequence_expr(node, context),
             Node::SetterProp(node) => parse_setter_prop(node, context),
             Node::SpreadElement(node) => parse_spread_element(node, context),
-            Node::Super(_) => vec!["super".into()],
+            Node::Super(_) => "super".into(),
             Node::TaggedTpl(node) => parse_tagged_tpl(node, context),
             Node::Tpl(node) => parse_tpl(node, context),
             Node::TplElement(node) => parse_tpl_element(node, context),
@@ -164,7 +169,7 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
             /* literals */
             Node::BigInt(node) => parse_big_int_literal(node, context),
             Node::Bool(node) => parse_bool_literal(node),
-            Node::Null(_) => vec!["null".into()],
+            Node::Null(_) => "null".into(),
             Node::Number(node) => parse_num_literal(node, context),
             Node::Regex(node) => parse_reg_exp_literal(node, context),
             Node::Str(node) => parse_string_literal(node, context),
@@ -217,7 +222,7 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
             Node::TsQualifiedName(node) => parse_qualified_name(node, context),
             Node::TsParenthesizedType(node) => parse_parenthesized_type(node, context),
             Node::TsRestType(node) => parse_rest_type(node, context),
-            Node::TsThisType(_) => vec!["this".into()],
+            Node::TsThisType(_) => "this".into(),
             Node::TsTupleType(node) => parse_tuple_type(node, context),
             Node::TsTypeAnn(node) => parse_type_ann(node, context),
             Node::TsTypeParam(node) => parse_type_param(node, context),
@@ -294,7 +299,7 @@ fn parse_node_with_inner_parse<'a>(node: Node<'a>, context: &mut Context<'a>, in
 
 /* class */
 
-fn parse_class_method<'a>(node: &'a ClassMethod, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_class_method<'a>(node: &'a ClassMethod, context: &mut Context<'a>) -> PrintItem {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: Some(&node.function.decorators),
         accessibility: node.accessibility,
@@ -312,9 +317,9 @@ fn parse_class_method<'a>(node: &'a ClassMethod, context: &mut Context<'a>) -> V
     }, context);
 }
 
-fn parse_class_prop<'a>(node: &'a ClassProp, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_class_prop<'a>(node: &'a ClassProp, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_decorators(&node.decorators, false, context));
+    items.push(parse_decorators(&node.decorators, false, context));
     if let Some(accessibility) = node.accessibility {
         items.push(format!("{} ", accessibility_to_str(&accessibility)).into());
     }
@@ -322,25 +327,25 @@ fn parse_class_prop<'a>(node: &'a ClassProp, context: &mut Context<'a>) -> Vec<P
     if node.is_abstract { items.push("abstract ".into()); }
     if node.readonly { items.push("readonly ".into()); }
     if node.computed { items.push("[".into()); }
-    items.extend(parse_node((&node.key).into(), context));
+    items.push(parse_node((&node.key).into(), context));
     if node.computed { items.push("]".into()); }
     if node.is_optional { items.push("?".into()); }
     if node.definite { items.push("!".into()); }
-    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
 
     if let Some(value) = &node.value {
         items.push(" = ".into());
-        items.extend(parse_node(value.into(), context));
+        items.push(parse_node(value.into(), context));
     }
 
     if context.config.class_property_semi_colon {
         items.push(";".into());
     }
 
-    return items;
+    return items.into();
 }
 
-fn parse_constructor<'a>(node: &'a Constructor, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_constructor<'a>(node: &'a Constructor, context: &mut Context<'a>) -> PrintItem {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: None,
         accessibility: node.accessibility,
@@ -358,27 +363,27 @@ fn parse_constructor<'a>(node: &'a Constructor, context: &mut Context<'a>) -> Ve
     }, context);
 }
 
-fn parse_decorator<'a>(node: &'a Decorator, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_decorator<'a>(node: &'a Decorator, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("@".into());
-    items.extend(parse_node((&node.expr).into(), context));
-    return items;
+    items.push(parse_node((&node.expr).into(), context));
+    return items.into();
 }
 
-fn parse_parameter_prop<'a>(node: &'a TsParamProp, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_parameter_prop<'a>(node: &'a TsParamProp, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_decorators(&node.decorators, true, context));
+    items.push(parse_decorators(&node.decorators, true, context));
     if let Some(accessibility) = node.accessibility {
         items.push(format!("{} ", accessibility_to_str(&accessibility)).into());
     }
     if node.readonly { items.push("readonly ".into()); }
-    items.extend(parse_node((&node.param).into(), context));
-    return items;
+    items.push(parse_node((&node.param).into(), context));
+    return items.into();
 }
 
 /* clauses */
 
-fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> PrintItem {
     // a bit overkill since the param will currently always just be an identifer
     let start_header_info = Info::new("catchClauseHeaderStart");
     let end_header_info = Info::new("catchClauseHeaderEnd");
@@ -389,13 +394,13 @@ fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> V
 
     if let Some(param) = &node.param {
         items.push(" (".into());
-        items.extend(parse_node(param.into(), context));
+        items.push(parse_node(param.into(), context));
         items.push(")".into());
     }
     items.push(end_header_info.clone().into());
 
     // not conditional... required
-    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: UseBraces::Always,
@@ -407,20 +412,20 @@ fn parse_catch_clause<'a>(node: &'a CatchClause, context: &mut Context<'a>) -> V
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
 
-    return items;
+    return items.into();
 }
 
 /* common */
 
-fn parse_computed_prop_name<'a>(node: &'a ComputedPropName, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_computed_prop_name<'a>(node: &'a ComputedPropName, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("[".into());
-    items.extend(parse_node((&node.expr).into(), context));
+    items.push(parse_node((&node.expr).into(), context));
     items.push("]".into());
-    return items;
+    return items.into();
 }
 
-fn parse_identifier<'a>(node: &'a Ident, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_identifier<'a>(node: &'a Ident, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push((&node.sym as &str).into());
 
@@ -433,14 +438,14 @@ fn parse_identifier<'a>(node: &'a Ident, context: &mut Context<'a>) -> Vec<Print
         }
     }
 
-    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
 
-    return items;
+    return items.into();
 }
 
 /* declarations */
 
-fn parse_class_decl<'a>(node: &'a ClassDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_class_decl<'a>(node: &'a ClassDecl, context: &mut Context<'a>) -> PrintItem {
     return parse_class_decl_or_expr(ClassDeclOrExpr {
         span: node.class.span,
         decorators: &node.class.decorators,
@@ -472,12 +477,12 @@ struct ClassDeclOrExpr<'a> {
     brace_position: BracePosition,
 }
 
-fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     let parent_kind = context.parent().kind();
     if parent_kind != NodeKind::ExportDecl && parent_kind != NodeKind::ExportDefaultDecl {
-        items.extend(parse_decorators(node.decorators, node.is_class_expr, context));
+        items.push(parse_decorators(node.decorators, node.is_class_expr, context));
     }
     let start_header_info = Info::new("startHeader");
     let parsed_header = {
@@ -491,35 +496,35 @@ fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context
 
         if let Some(ident) = node.ident {
             items.push(" ".into());
-            items.extend(parse_node(ident, context));
+            items.push(parse_node(ident, context));
         }
         if let Some(type_params) = node.type_params {
-            items.extend(parse_node(type_params, context));
+            items.push(parse_node(type_params, context));
         }
         if let Some(super_class) = node.super_class {
             items.push(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_header_info.clone(), None).into());
             items.push(conditions::indent_if_start_of_line({
                 let mut items = Vec::new();
                 items.push("extends ".into());
-                items.extend(parse_node(super_class, context));
+                items.push(parse_node(super_class, context));
                 if let Some(super_type_params) = node.super_type_params {
-                    items.extend(parse_node(super_type_params, context));
+                    items.push(parse_node(super_type_params, context));
                 }
-                items
+                items.into()
             }).into());
         }
-        items.extend(parse_extends_or_implements("implements", node.implements, start_header_info.clone(), context));
-        items
+        items.push(parse_extends_or_implements("implements", node.implements, start_header_info.clone(), context));
+        items.into()
     };
 
     if node.is_class_expr {
         items.push(conditions::indent_if_start_of_line(parsed_header).into());
     } else {
-        items.extend(parsed_header);
+        items.push(parsed_header);
     }
 
     // parse body
-    items.extend(parse_membered_body(ParseMemberedBodyOptions {
+    items.push(parse_membered_body(ParseMemberedBodyOptions {
         span: node.span,
         members: node.members,
         start_header_info: Some(start_header_info),
@@ -530,38 +535,38 @@ fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context
         trailing_commas: None,
     }, context));
 
-    return items;
+    return items.into();
 }
 
-fn parse_export_decl<'a>(node: &'a ExportDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_export_decl<'a>(node: &'a ExportDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if let Decl::Class(class_decl) = &node.decl {
-        items.extend(parse_decorators(&class_decl.class.decorators, false, context));
+        items.push(parse_decorators(&class_decl.class.decorators, false, context));
     }
     items.push("export ".into());
-    items.extend(parse_node((&node.decl).into(), context));
-    items
+    items.push(parse_node((&node.decl).into(), context));
+    items.into()
 }
 
-fn parse_export_default_decl<'a>(node: &'a ExportDefaultDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_export_default_decl<'a>(node: &'a ExportDefaultDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if let DefaultDecl::Class(class_expr) = &node.decl {
-        items.extend(parse_decorators(&class_expr.class.decorators, false, context));
+        items.push(parse_decorators(&class_expr.class.decorators, false, context));
     }
     items.push("export default ".into());
-    items.extend(parse_node((&node.decl).into(), context));
-    items
+    items.push(parse_node((&node.decl).into(), context));
+    items.into()
 }
 
-fn parse_export_default_expr<'a>(node: &'a ExportDefaultExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_export_default_expr<'a>(node: &'a ExportDefaultExpr, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("export default ".into());
-    items.extend(parse_node((&node.expr).into(), context));
+    items.push(parse_node((&node.expr).into(), context));
     if context.config.export_default_expression_semi_colon { items.push(";".into()); }
-    items
+    items.into()
 }
 
-fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> PrintItem {
     let start_header_info = Info::new("startHeader");
     let mut items = Vec::new();
 
@@ -571,11 +576,11 @@ fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> Vec<P
     if node.declare { items.push("declare ".into()); }
     if node.is_const { items.push("const ".into()); }
     items.push("enum ".into());
-    items.extend(parse_node((&node.id).into(), context));
+    items.push(parse_node((&node.id).into(), context));
 
     // body
     let member_spacing = context.config.enum_declaration_member_spacing;
-    items.extend(parse_membered_body(ParseMemberedBodyOptions {
+    items.push(parse_membered_body(ParseMemberedBodyOptions {
         span: node.span,
         members: node.members.iter().map(|x| x.into()).collect(),
         start_header_info: Some(start_header_info),
@@ -590,11 +595,12 @@ fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> Vec<P
         trailing_commas: Some(context.config.enum_declaration_trailing_commas),
     }, context));
 
-    return items;
+    return items.into();
 }
 
-fn parse_enum_member<'a>(node: &'a TsEnumMember, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.id).into(), context);
+fn parse_enum_member<'a>(node: &'a TsEnumMember, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.id).into(), context));
 
     if let Some(init) = &node.init {
         items.push(match init.kind() {
@@ -605,15 +611,15 @@ fn parse_enum_member<'a>(node: &'a TsEnumMember, context: &mut Context<'a>) -> V
         items.push(conditions::indent_if_start_of_line({
             let mut items = Vec::new();
             items.push("= ".into());
-            items.extend(parse_node(init.into(), context));
-            items
+            items.push(parse_node(init.into(), context));
+            items.into()
         }).into());
     }
 
-    items
+    items.into()
 }
 
-fn parse_export_named_decl<'a>(node: &'a NamedExport, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_export_named_decl<'a>(node: &'a NamedExport, context: &mut Context<'a>) -> PrintItem {
     // fill specifiers
     let mut default_export: Option<&DefaultExportSpecifier> = None;
     let mut namespace_export: Option<&NamespaceExportSpecifier> = None;
@@ -633,32 +639,32 @@ fn parse_export_named_decl<'a>(node: &'a NamedExport, context: &mut Context<'a>)
     items.push("export ".into());
 
     if let Some(default_export) = default_export {
-        items.extend(parse_node(default_export.into(), context));
+        items.push(parse_node(default_export.into(), context));
     } else if !named_exports.is_empty() {
-        items.extend(parse_named_import_or_export_specifiers(
+        items.push(parse_named_import_or_export_specifiers(
             NamedImportOrExportDeclaration::Export(node),
             named_exports.into_iter().map(|x| x.into()).collect(),
             context
         ));
     } else if let Some(namespace_export) = namespace_export {
-        items.extend(parse_node(namespace_export.into(), context));
+        items.push(parse_node(namespace_export.into(), context));
     } else {
         items.push("{}".into());
     }
 
     if let Some(src) = &node.src {
         items.push(" from ".into());
-        items.extend(parse_node(src.into(), context));
+        items.push(parse_node(src.into(), context));
     }
 
     if context.config.export_named_declaration_semi_colon {
         items.push(";".into());
     }
 
-    items
+    items.into()
 }
 
-fn parse_function_decl<'a>(node: &'a FnDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_function_decl<'a>(node: &'a FnDecl, context: &mut Context<'a>) -> PrintItem {
     parse_function_decl_or_expr(FunctionDeclOrExprNode {
         is_func_decl: true,
         ident: Some(&node.ident),
@@ -674,7 +680,7 @@ struct FunctionDeclOrExprNode<'a> {
     func: &'a Function,
 }
 
-fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let start_header_info = Info::new("functionHeaderStart");
     let func = node.func;
@@ -686,12 +692,12 @@ fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &m
     if func.is_generator { items.push("*".into()); }
     if let Some(ident) = node.ident {
         items.push(" ".into());
-        items.extend(parse_node(ident.into(), context));
+        items.push(parse_node(ident.into(), context));
     }
-    if let Some(type_params) = &func.type_params { items.extend(parse_node(type_params.into(), context)); }
+    if let Some(type_params) = &func.type_params { items.push(parse_node(type_params.into(), context)); }
     if get_use_space_before_parens(node.is_func_decl, context) { items.push(" ".into()); }
 
-    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: func.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: if node.is_func_decl {
             context.config.function_declaration_force_multi_line_parameters
@@ -713,20 +719,20 @@ fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &m
         };
         let open_brace_token = context.token_finder.get_first_open_brace_token_within(&body);
 
-        items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+        items.push(parse_brace_separator(ParseBraceSeparatorOptions {
             brace_position: brace_position,
             open_brace_token: open_brace_token,
             start_header_info: Some(start_header_info),
         }, context));
 
-        items.extend(parse_node(body.into(), context));
+        items.push(parse_node(body.into(), context));
     } else {
         if context.config.function_declaration_semi_colon {
             items.push(";".into());
         }
     }
 
-    return items;
+    return items.into();
 
     fn get_use_space_before_parens(is_func_decl: bool, context: &mut Context) -> bool {
         if is_func_decl {
@@ -737,7 +743,7 @@ fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &m
     }
 }
 
-fn parse_import_decl<'a>(node: &'a ImportDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_import_decl<'a>(node: &'a ImportDecl, context: &mut Context<'a>) -> PrintItem {
     // fill specifiers
     let mut default_import: Option<&ImportDefault> = None;
     let mut namespace_import: Option<&ImportStarAs> = None;
@@ -756,15 +762,15 @@ fn parse_import_decl<'a>(node: &'a ImportDecl, context: &mut Context<'a>) -> Vec
     items.push("import ".into());
 
     if let Some(default_import) = default_import {
-        items.extend(parse_node(default_import.into(), context));
+        items.push(parse_node(default_import.into(), context));
         if namespace_import.is_some() || !named_imports.is_empty() {
             items.push(", ".into());
         }
     }
     if let Some(namespace_import) = namespace_import {
-        items.extend(parse_node(namespace_import.into(), context));
+        items.push(parse_node(namespace_import.into(), context));
     }
-    items.extend(parse_named_import_or_export_specifiers(
+    items.push(parse_named_import_or_export_specifiers(
         NamedImportOrExportDeclaration::Import(node),
         named_imports.into_iter().map(|x| x.into()).collect(),
         context
@@ -772,32 +778,32 @@ fn parse_import_decl<'a>(node: &'a ImportDecl, context: &mut Context<'a>) -> Vec
 
     if has_from { items.push(" from ".into()); }
 
-    items.extend(parse_node((&node.src).into(), context));
+    items.push(parse_node((&node.src).into(), context));
 
     if context.config.import_declaration_semi_colon {
         items.push(";".into());
     }
 
-    return items;
+    return items.into();
 }
 
-fn parse_import_equals_decl<'a>(node: &'a TsImportEqualsDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_import_equals_decl<'a>(node: &'a TsImportEqualsDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if node.is_export {
         items.push("export ".into());
     }
 
     items.push("import ".into());
-    items.extend(parse_node((&node.id).into(), context));
+    items.push(parse_node((&node.id).into(), context));
     items.push(" = ".into());
-    items.extend(parse_node((&node.module_ref).into(), context));
+    items.push(parse_node((&node.module_ref).into(), context));
 
     if context.config.import_equals_declaration_semi_colon { items.push(";".into()); }
 
-    return items;
+    return items.into();
 }
 
-fn parse_interface_decl<'a>(node: &'a TsInterfaceDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_interface_decl<'a>(node: &'a TsInterfaceDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let start_header_info = Info::new("startHeader");
     items.push(start_header_info.clone().into());
@@ -805,15 +811,15 @@ fn parse_interface_decl<'a>(node: &'a TsInterfaceDecl, context: &mut Context<'a>
 
     if node.declare { items.push("declare ".into()); }
     items.push("interface ".into());
-    items.extend(parse_node((&node.id).into(), context));
-    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
-    items.extend(parse_extends_or_implements("extends", node.extends.iter().map(|x| x.into()).collect(), start_header_info, context));
-    items.extend(parse_node((&node.body).into(), context));
+    items.push(parse_node((&node.id).into(), context));
+    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
+    items.push(parse_extends_or_implements("extends", node.extends.iter().map(|x| x.into()).collect(), start_header_info, context));
+    items.push(parse_node((&node.body).into(), context));
 
-    return items;
+    return items.into();
 }
 
-fn parse_module_decl<'a>(node: &'a TsModuleDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_module_decl<'a>(node: &'a TsModuleDecl, context: &mut Context<'a>) -> PrintItem {
     parse_module_or_namespace_decl(ModuleOrNamespaceDecl {
         span: node.span,
         declare: node.declare,
@@ -823,7 +829,7 @@ fn parse_module_decl<'a>(node: &'a TsModuleDecl, context: &mut Context<'a>) -> V
     }, context)
 }
 
-fn parse_namespace_decl<'a>(node: &'a TsNamespaceDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_namespace_decl<'a>(node: &'a TsNamespaceDecl, context: &mut Context<'a>) -> PrintItem {
     parse_module_or_namespace_decl(ModuleOrNamespaceDecl {
         span: node.span,
         declare: node.declare,
@@ -841,7 +847,7 @@ struct ModuleOrNamespaceDecl<'a> {
     pub body: Option<&'a TsNamespaceBody>,
 }
 
-fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     let start_header_info = Info::new("startHeader");
@@ -850,23 +856,23 @@ fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: 
     if node.declare { items.push("declare ".into()); }
     if node.global {
         items.push("global".into());
-        // items.extend(parse_node(node.id.into(), context));
+        // items.push(parse_node(node.id.into(), context));
     } else {
         let has_namespace_keyword = context.token_finder.get_char_at(&node.span.lo()) == 'n';
         items.push(if has_namespace_keyword { "namespace " } else { "module " }.into());
     }
 
-    items.extend(parse_node(node.id.into(), context));
-    items.extend(parse_body(node.body, start_header_info, context));
+    items.push(parse_node(node.id.into(), context));
+    items.push(parse_body(node.body, start_header_info, context));
 
-    return items;
+    return items.into();
 
-    fn parse_body<'a>(body: Option<&'a TsNamespaceBody>, start_header_info: Info, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_body<'a>(body: Option<&'a TsNamespaceBody>, start_header_info: Info, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
         if let Some(body) = &body {
             match body {
                 TsNamespaceBody::TsModuleBlock(block) => {
-                    items.extend(parse_membered_body(ParseMemberedBodyOptions {
+                    items.push(parse_membered_body(ParseMemberedBodyOptions {
                         span: block.span,
                         members: block.body.iter().map(|x| x.into()).collect(),
                         start_header_info: Some(start_header_info),
@@ -879,8 +885,8 @@ fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: 
                 },
                 TsNamespaceBody::TsNamespaceDecl(decl) => {
                     items.push(".".into());
-                    items.extend(parse_node((&decl.id).into(), context));
-                    items.extend(parse_body(Some(&*decl.body), start_header_info, context));
+                    items.push(parse_node((&decl.id).into(), context));
+                    items.push(parse_body(Some(&*decl.body), start_header_info, context));
                 }
             }
         }
@@ -888,32 +894,32 @@ fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: 
             items.push(";".into());
         }
 
-        return items;
+        return items.into();
     }
 }
 
-fn parse_type_alias<'a>(node: &'a TsTypeAliasDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_alias<'a>(node: &'a TsTypeAliasDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if node.declare { items.push("declare ".into()); }
     items.push("type ".into());
-    items.extend(parse_node((&node.id).into(), context));
+    items.push(parse_node((&node.id).into(), context));
     if let Some(type_params) = &node.type_params {
-        items.extend(parse_node(type_params.into(), context));
+        items.push(parse_node(type_params.into(), context));
     }
     items.push(" = ".into());
-    items.extend(parse_node((&node.type_ann).into(), context));
+    items.push(parse_node((&node.type_ann).into(), context));
 
     if context.config.type_alias_semi_colon { items.push(";".into()); }
 
-    return items;
+    return items.into();
 }
 
 /* exports */
 
-fn parse_named_import_or_export_specifiers<'a>(parent_decl: NamedImportOrExportDeclaration<'a>, specifiers: Vec<Node<'a>>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_named_import_or_export_specifiers<'a>(parent_decl: NamedImportOrExportDeclaration<'a>, specifiers: Vec<Node<'a>>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if specifiers.is_empty() {
-        return items;
+        return items.into();
     }
 
     let use_space = get_use_space(&parent_decl, context);
@@ -936,25 +942,21 @@ fn parse_named_import_or_export_specifiers<'a>(parent_decl: NamedImportOrExportD
             }
 
             let parsed_specifier = parse_node(specifier.into(), context);
-            items.extend(if use_new_lines {
+            items.push(if use_new_lines {
                 parsed_specifier
             } else {
-                vec![conditions::indent_if_start_of_line(parser_helpers::new_line_group(parsed_specifier)).into()]
+                conditions::indent_if_start_of_line(parser_helpers::new_line_group(parsed_specifier)).into()
             });
         }
-        items
+        items.into()
     };
 
-    items.extend(if use_new_lines {
-        parser_helpers::with_indent(specifiers)
-    } else {
-        specifiers
-    });
+    items.push(if use_new_lines { parser_helpers::with_indent(specifiers) } else { specifiers });
 
     items.push(brace_separator);
     items.push("}".into());
 
-    return items;
+    return items.into();
 
     fn get_use_space(parent_decl: &NamedImportOrExportDeclaration, context: &mut Context) -> bool {
         match parent_decl {
@@ -966,7 +968,7 @@ fn parse_named_import_or_export_specifiers<'a>(parent_decl: NamedImportOrExportD
 
 /* expressions */
 
-fn parse_array_expr<'a>(node: &'a ArrayLit, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_array_expr<'a>(node: &'a ArrayLit, context: &mut Context<'a>) -> PrintItem {
     parse_array_like_nodes(ParseArrayLikeNodesOptions {
         parent_span: node.span,
         elements: node.elems.iter().map(|x| x.as_ref().map(|elem| elem.into())).collect(),
@@ -974,17 +976,17 @@ fn parse_array_expr<'a>(node: &'a ArrayLit, context: &mut Context<'a>) -> Vec<Pr
     }, context)
 }
 
-fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let header_start_info = Info::new("arrowFunctionExpressionHeaderStart");
     let should_use_params = get_should_use_params(&node, context);
 
     items.push(header_start_info.clone().into());
     if node.is_async { items.push("async ".into()); }
-    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
+    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
 
     if should_use_params {
-        items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+        items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
             nodes: node.params.iter().map(|node| node.into()).collect(),
             force_multi_line_when_multiple_lines: context.config.arrow_function_expression_force_multi_line_parameters,
             custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -994,7 +996,7 @@ fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> 
             }, context)),
         }, context));
     } else {
-        items.extend(parse_node(node.params.iter().next().unwrap().into(), context));
+        items.push(parse_node(node.params.iter().next().unwrap().into(), context));
     }
 
     items.push(" =>".into());
@@ -1003,15 +1005,15 @@ fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> 
         BlockStmtOrExpr::BlockStmt(stmt) => context.token_finder.get_first_open_brace_token_within(&stmt),
         _ => None,
     };
-    items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+    items.push(parse_brace_separator(ParseBraceSeparatorOptions {
         brace_position: context.config.arrow_function_expression_brace_position,
         open_brace_token: open_brace_token,
         start_header_info: Some(header_start_info),
     }, context));
 
-    items.extend(parse_node((&node.body).into(), context));
+    items.push(parse_node((&node.body).into(), context));
 
-    return items;
+    return items.into();
 
     fn get_should_use_params(node: &ArrowExpr, context: &mut Context) -> bool {
         let requires_parens = node.params.len() != 1 || node.return_type.is_some() || is_first_param_not_identifier_or_has_type_annotation(&node.params);
@@ -1044,41 +1046,44 @@ fn parse_arrow_func_expr<'a>(node: &'a ArrowExpr, context: &mut Context<'a>) -> 
     }
 }
 
-fn parse_as_expr<'a>(node: &'a TsAsExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.expr).into(), context);
+fn parse_as_expr<'a>(node: &'a TsAsExpr, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.expr).into(), context));
     items.push(" as ".into());
     items.push(conditions::with_indent_if_start_of_line_indented(parse_node((&node.type_ann).into(), context)).into());
-    items
+    items.into()
 }
 
-fn parse_const_assertion<'a>(node: &'a TsConstAssertion, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.expr).into(), context);
+fn parse_const_assertion<'a>(node: &'a TsConstAssertion, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.expr).into(), context));
     items.push(" as const".into());
-    items
+    items.into()
 }
 
-fn parse_assignment_expr<'a>(node: &'a AssignExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.left).into(), context);
+fn parse_assignment_expr<'a>(node: &'a AssignExpr, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.left).into(), context));
     items.push(format!(" {} ", node.op).into());
     items.push(conditions::with_indent_if_start_of_line_indented(parse_node((&node.right).into(), context)).into());
-    items
+    items.into()
 }
 
-fn parse_await_expr<'a>(node: &'a AwaitExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_await_expr<'a>(node: &'a AwaitExpr, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("await ".into());
-    items.extend(parse_node((&node.arg).into(), context));
-    items
+    items.push(parse_node((&node.arg).into(), context));
+    items.into()
 }
 
-fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintItem {
     return if is_expression_breakable(&node.op) {
         inner_parse(node, context)
     } else {
         new_line_group(inner_parse(node, context))
     };
 
-    fn inner_parse<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn inner_parse<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> PrintItem {
         // todo: clean this up
         let operator_token = context.token_finder.get_first_operator_after(&node.left, node.op.as_str()).unwrap();
         let operator_position = get_operator_position(&node, &operator_token, context);
@@ -1103,18 +1108,23 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> Vec<Pr
         }
 
         items.push(indent_if_necessary(node_left.lo(), top_most_expr_start, top_most_info.clone(), indent_disabled, {
-            new_line_group_if_necessary(&node_left, parse_node_with_inner_parse(node_left_node, context, move |mut items| {
+            new_line_group_if_necessary(&node_left, parse_node_with_inner_parse(node_left_node, context, move |item| {
                 if operator_position == OperatorPosition::SameLine {
+                    let mut items = vec![item];
                     if use_space_surrounding_operator {
                         items.push(" ".into());
                     }
                     items.push(node_op.as_str().into());
+                    items.into()
+                } else {
+                    item
                 }
-                items
             }))
         }));
 
-        items.extend(parse_comments_as_trailing(&operator_token, operator_token.trailing_comments(context), context));
+        if let Some(parsed_comments) = parse_comments_as_trailing(&operator_token, operator_token.trailing_comments(context), context) {
+            items.push(parsed_comments);
+        }
 
         items.push(if use_new_lines {
             PrintItem::NewLine
@@ -1132,26 +1142,24 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> Vec<Pr
         items.push(indent_if_necessary(node_right.lo(), top_most_expr_start, top_most_info, indent_disabled, {
             let mut items = Vec::new();
             let use_new_line_group = get_use_new_line_group(&node_right);
-            items.extend(parse_comments_as_leading(node_right, operator_token.leading_comments(context), context));
-            items.extend(parse_node_with_inner_parse(node_right.into(), context, move |items| {
-                let mut new_items = Vec::new();
+            if let Some(parsed_comments) = parse_comments_as_leading(node_right, operator_token.leading_comments(context), context) {
+                items.push(parsed_comments);
+            }
+            items.push(parse_node_with_inner_parse(node_right.into(), context, move |item| {
+                let mut items = Vec::new();
                 if operator_position == OperatorPosition::NextLine {
-                    new_items.push(node_op.as_str().into());
+                    items.push(node_op.as_str().into());
                     if use_space_surrounding_operator {
-                        new_items.push(" ".into());
+                        items.push(" ".into());
                     }
                 }
-                new_items.extend(if use_new_line_group {
-                    new_line_group(items)
-                } else {
-                    items
-                });
-                new_items
+                items.push(if use_new_line_group { new_line_group(item) } else { item });
+                items.into()
             }));
-            items
+            items.into()
         }));
 
-        return items;
+        return items.into();
     }
 
     fn indent_if_necessary(
@@ -1159,7 +1167,7 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> Vec<Pr
         top_most_expr_start: BytePos,
         top_most_info: Info,
         indent_disabled: bool,
-        items: Vec<PrintItem>
+        items: PrintItem
     ) -> PrintItem {
         let is_left_most_node = top_most_expr_start == current_node_start;
         Condition::new("indentIfNecessaryForBinaryExpressions", ConditionProperties {
@@ -1174,7 +1182,7 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> Vec<Pr
         }).into()
     }
 
-    fn new_line_group_if_necessary(expr: &Expr, items: Vec<PrintItem>) -> Vec<PrintItem> {
+    fn new_line_group_if_necessary(expr: &Expr, items: PrintItem) -> PrintItem {
         match get_use_new_line_group(expr) {
             true => parser_helpers::new_line_group(items),
             false => items,
@@ -1250,20 +1258,20 @@ fn parse_binary_expr<'a>(node: &'a BinExpr, context: &mut Context<'a>) -> Vec<Pr
     }
 }
 
-fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItem {
     return if is_test_library_call_expr(&node, context) {
         parse_test_library_call_expr(node, context)
     } else {
         inner_parse(node, context)
     };
 
-    fn inner_parse<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn inner_parse<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
 
-        items.extend(parse_node((&node.callee).into(), context));
+        items.push(parse_node((&node.callee).into(), context));
 
         if let Some(type_args) = &node.type_args {
-            items.extend(parse_node(type_args.into(), context));
+            items.push(parse_node(type_args.into(), context));
         }
 
         if is_optional(context) {
@@ -1276,16 +1284,16 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> Vec<Pri
             custom_close_paren: None,
         }, context)).into());
 
-        items
+        items.into()
     }
 
-    fn parse_test_library_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_test_library_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
-        items.extend(parse_test_library_callee(&node.callee, context));
-        items.extend(parse_test_library_arguments(&node.args, context));
-        return items;
+        items.push(parse_test_library_callee(&node.callee, context));
+        items.push(parse_test_library_arguments(&node.args, context));
+        return items.into();
 
-        fn parse_test_library_callee<'a>(callee: &'a ExprOrSuper, context: &mut Context<'a>) -> Vec<PrintItem> {
+        fn parse_test_library_callee<'a>(callee: &'a ExprOrSuper, context: &mut Context<'a>) -> PrintItem {
             match callee {
                 // todo: use box pattern matching once supported in rust stable
                 ExprOrSuper::Expr(expr) => {
@@ -1293,10 +1301,10 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> Vec<Pri
                     match expr {
                         Expr::Member(member_expr) => {
                             let mut items = Vec::new();
-                            items.extend(parse_node((&member_expr.obj).into(), context));
+                            items.push(parse_node((&member_expr.obj).into(), context));
                             items.push(".".into());
-                            items.extend(parse_node((&member_expr.prop).into(), context));
-                            items
+                            items.push(parse_node((&member_expr.prop).into(), context));
+                            items.into()
                         },
                         _=> parse_node(expr.into(), context),
                     }
@@ -1305,20 +1313,39 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> Vec<Pri
             }
         }
 
-        fn parse_test_library_arguments<'a>(args: &'a Vec<ExprOrSpread>, context: &mut Context<'a>) -> Vec<PrintItem> {
+        fn parse_test_library_arguments<'a>(args: &'a Vec<ExprOrSpread>, context: &mut Context<'a>) -> PrintItem {
             let mut items = Vec::new();
             items.push("(".into());
-            items.extend(parse_node_with_inner_parse((&args[0]).into(), context, |items| {
+            items.push(parse_node_with_inner_parse((&args[0]).into(), context, |item| {
                 // force everything to go onto one line
-                let mut items = items.into_iter().filter(|item| !item.is_signal()).collect::<Vec<PrintItem>>();
-                items.push(",".into());
-                items
+                vec![filter_signals(item), ",".into()].into()
             }));
             items.push(" ".into());
-            items.extend(parse_node((&args[1]).into(), context));
+            items.push(parse_node((&args[1]).into(), context));
             items.push(")".into());
 
-            return items;
+            return items.into();
+        }
+
+        pub fn filter_signals(item: PrintItem) -> PrintItem {
+            let mut items = Vec::new();
+            handle_item(item, &mut items);
+            return items.into();
+
+            fn handle_item(item: PrintItem, items: &mut Vec<PrintItem>) {
+                match item {
+                    PrintItem::Items(print_item_items) => {
+                        let print_item_items = std::rc::Rc::try_unwrap(print_item_items).ok()
+                            .expect("Cannot filter signals in this scenario because items have already been cloned.");
+                        for item in print_item_items.into_iter() {
+                            handle_item(item, items);
+                        }
+                    },
+                    PrintItem::Condition(condition) => items.push(PrintItem::Condition(condition)),
+                    PrintItem::Info(info) => items.push(PrintItem::Info(info)),
+                    _ => {},
+                }
+            }
         }
     }
 
@@ -1367,7 +1394,7 @@ fn parse_call_expr<'a>(node: &'a CallExpr, context: &mut Context<'a>) -> Vec<Pri
     }
 }
 
-fn parse_class_expr<'a>(node: &'a ClassExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_class_expr<'a>(node: &'a ClassExpr, context: &mut Context<'a>) -> PrintItem {
     return parse_class_decl_or_expr(ClassDeclOrExpr {
         span: node.class.span,
         decorators: &node.class.decorators,
@@ -1384,7 +1411,7 @@ fn parse_class_expr<'a>(node: &'a ClassExpr, context: &mut Context<'a>) -> Vec<P
     }, context);
 }
 
-fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> PrintItem {
     let operator_token = context.token_finder.get_first_operator_after(&node.test, "?").unwrap();
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&node.test, &node.cons, context)
         || node_helpers::get_use_new_lines_for_nodes(&node.cons, &node.alt, context);
@@ -1395,12 +1422,13 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
     let mut items = Vec::new();
 
     items.push(start_info.clone().into());
-    items.extend(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.test).into(), context, {
-        move |mut items| {
+    items.push(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.test).into(), context, {
+        move |mut item| {
             if operator_position == OperatorPosition::SameLine {
-                items.push(" ?".into());
+                vec![item, " ?".into()].into()
+            } else {
+                item
             }
-            items
         }
     })));
 
@@ -1418,15 +1446,16 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
         if operator_position == OperatorPosition::NextLine {
             items.push("? ".into());
         }
-        items.extend(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.cons).into(), context, {
-            move |mut items| {
+        items.push(parser_helpers::new_line_group(parse_node_with_inner_parse((&node.cons).into(), context, {
+            move |item| {
                 if operator_position == OperatorPosition::SameLine {
-                    items.push(" :".into());
+                    vec![item, " :".into()].into()
+                } else {
+                    item
                 }
-                items
             }
         })));
-        items
+        items.into()
     }).into());
 
     if use_new_lines {
@@ -1441,12 +1470,12 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
             items.push(": ".into());
         }
         items.push(before_alternate_info.into());
-        items.extend(parser_helpers::new_line_group(parse_node((&node.alt).into(), context)));
+        items.push(parser_helpers::new_line_group(parse_node((&node.alt).into(), context)));
         items.push(end_info.into());
-        items
+        items.into()
     }).into());
 
-    return items;
+    return items.into();
 
     fn get_operator_position(node: &CondExpr, operator_token: &TokenAndSpan, context: &mut Context) -> OperatorPosition {
         match context.config.conditional_expression_operator_position {
@@ -1463,23 +1492,23 @@ fn parse_conditional_expr<'a>(node: &'a CondExpr, context: &mut Context<'a>) -> 
     }
 }
 
-fn parse_expr_or_spread<'a>(node: &'a ExprOrSpread, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_expr_or_spread<'a>(node: &'a ExprOrSpread, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if node.spread.is_some() { items.push("...".into()); }
-    items.extend(parse_node((&node.expr).into(), context));
-    items
+    items.push(parse_node((&node.expr).into(), context));
+    items.into()
 }
 
-fn parse_expr_with_type_args<'a>(node: &'a TsExprWithTypeArgs, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut vec = Vec::new();
-    vec.extend(parse_node((&node.expr).into(), context));
+fn parse_expr_with_type_args<'a>(node: &'a TsExprWithTypeArgs, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.expr).into(), context));
     if let Some(type_args) = &node.type_args {
-        vec.extend(parse_node(type_args.into(), context));
+        items.push(parse_node(type_args.into(), context));
     }
-    return vec;
+    return items.into();
 }
 
-fn parse_fn_expr<'a>(node: &'a FnExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_fn_expr<'a>(node: &'a FnExpr, context: &mut Context<'a>) -> PrintItem {
     parse_function_decl_or_expr(FunctionDeclOrExprNode {
         is_func_decl: false,
         ident: node.ident.as_ref().clone(),
@@ -1488,7 +1517,7 @@ fn parse_fn_expr<'a>(node: &'a FnExpr, context: &mut Context<'a>) -> Vec<PrintIt
     }, context)
 }
 
-fn parse_getter_prop<'a>(node: &'a GetterProp, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_getter_prop<'a>(node: &'a GetterProp, context: &mut Context<'a>) -> PrintItem {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: None,
         accessibility: None,
@@ -1506,13 +1535,14 @@ fn parse_getter_prop<'a>(node: &'a GetterProp, context: &mut Context<'a>) -> Vec
     }, context);
 }
 
-fn parse_key_value_prop<'a>(node: &'a KeyValueProp, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.key).into(), context);
-    items.extend(parse_node_with_preceeding_colon(Some((&node.value).into()), context));
-    return items;
+fn parse_key_value_prop<'a>(node: &'a KeyValueProp, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.key).into(), context));
+    items.push(parse_node_with_preceeding_colon(Some((&node.value).into()), context));
+    return items.into();
 }
 
-fn parse_member_expr<'a>(node: &'a MemberExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_member_expr<'a>(node: &'a MemberExpr, context: &mut Context<'a>) -> PrintItem {
     return parse_for_member_like_expr(MemberLikeExpr {
         left_node: (&node.obj).into(),
         right_node: (&node.prop).into(),
@@ -1520,7 +1550,7 @@ fn parse_member_expr<'a>(node: &'a MemberExpr, context: &mut Context<'a>) -> Vec
     }, context);
 }
 
-fn parse_meta_prop_expr<'a>(node: &'a MetaPropExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_meta_prop_expr<'a>(node: &'a MetaPropExpr, context: &mut Context<'a>) -> PrintItem {
     return parse_for_member_like_expr(MemberLikeExpr {
         left_node: (&node.meta).into(),
         right_node: (&node.prop).into(),
@@ -1528,30 +1558,31 @@ fn parse_meta_prop_expr<'a>(node: &'a MetaPropExpr, context: &mut Context<'a>) -
     }, context);
 }
 
-fn parse_new_expr<'a>(node: &'a NewExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_new_expr<'a>(node: &'a NewExpr, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("new ".into());
-    items.extend(parse_node((&node.callee).into(), context));
-    if let Some(type_args) = &node.type_args { items.extend(parse_node(type_args.into(), context)); }
+    items.push(parse_node((&node.callee).into(), context));
+    if let Some(type_args) = &node.type_args { items.push(parse_node(type_args.into(), context)); }
     let args = match node.args.as_ref() {
         Some(args) => args.iter().map(|node| node.into()).collect(),
         None => Vec::new(),
     };
-    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: args,
         force_multi_line_when_multiple_lines: context.config.new_expression_force_multi_line_arguments,
         custom_close_paren: None,
     }, context));
-    return items;
+    return items.into();
 }
 
-fn parse_non_null_expr<'a>(node: &'a TsNonNullExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.expr).into(), context);
+fn parse_non_null_expr<'a>(node: &'a TsNonNullExpr, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.expr).into(), context));
     items.push("!".into());
-    return items;
+    return items.into();
 }
 
-fn parse_object_lit<'a>(node: &'a ObjectLit, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_object_lit<'a>(node: &'a ObjectLit, context: &mut Context<'a>) -> PrintItem {
     return parse_object_like_node(ParseObjectLikeNodeOptions {
         node_span: node.span,
         members: node.props.iter().map(|x| x.into()).collect(),
@@ -1559,19 +1590,19 @@ fn parse_object_lit<'a>(node: &'a ObjectLit, context: &mut Context<'a>) -> Vec<P
     }, context);
 }
 
-fn parse_paren_expr<'a>(node: &'a ParenExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
-    return vec![conditions::with_indent_if_start_of_line_indented(parse_node_in_parens(
+fn parse_paren_expr<'a>(node: &'a ParenExpr, context: &mut Context<'a>) -> PrintItem {
+    return conditions::with_indent_if_start_of_line_indented(parse_node_in_parens(
         (&node.expr).into(),
         |context| parse_node((&node.expr).into(), context),
         context
-    )).into()];
+    )).into();
 }
 
-fn parse_sequence_expr<'a>(node: &'a SeqExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_sequence_expr<'a>(node: &'a SeqExpr, context: &mut Context<'a>) -> PrintItem {
     parse_comma_separated_values(node.exprs.iter().map(|x| x.into()).collect(), |_| { Some(false) }, context)
 }
 
-fn parse_setter_prop<'a>(node: &'a SetterProp, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_setter_prop<'a>(node: &'a SetterProp, context: &mut Context<'a>) -> PrintItem {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: None,
         accessibility: None,
@@ -1589,43 +1620,44 @@ fn parse_setter_prop<'a>(node: &'a SetterProp, context: &mut Context<'a>) -> Vec
     }, context);
 }
 
-fn parse_spread_element<'a>(node: &'a SpreadElement, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_spread_element<'a>(node: &'a SpreadElement, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("...".into());
-    items.extend(parse_node((&node.expr).into(), context));
-    return items;
+    items.push(parse_node((&node.expr).into(), context));
+    return items.into();
 }
 
-fn parse_tagged_tpl<'a>(node: &'a TaggedTpl, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.tag).into(), context);
-    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
+fn parse_tagged_tpl<'a>(node: &'a TaggedTpl, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.tag).into(), context));
+    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
     items.push(PrintItem::SpaceOrNewLine);
     items.push(conditions::indent_if_start_of_line(parse_template_literal(&node.quasis, &node.exprs.iter().map(|x| &**x).collect(), context)).into());
-    return items;
+    return items.into();
 }
 
-fn parse_tpl<'a>(node: &'a Tpl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_tpl<'a>(node: &'a Tpl, context: &mut Context<'a>) -> PrintItem {
     parse_template_literal(&node.quasis, &node.exprs.iter().map(|x| &**x).collect(), context)
 }
 
-fn parse_tpl_element<'a>(node: &'a TplElement, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_tpl_element<'a>(node: &'a TplElement, context: &mut Context<'a>) -> PrintItem {
     parse_raw_string(node.text(context).into())
 }
 
-fn parse_template_literal<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_template_literal<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>, context: &mut Context<'a>) -> PrintItem {
     return parser_helpers::new_line_group({
         let mut items = Vec::new();
         items.push("`".into());
         items.push(PrintItem::StartIgnoringIndent);
         for node in get_nodes(quasis, exprs) {
             if node.kind() == NodeKind::TplElement {
-                items.extend(parse_node(node, context));
+                items.push(parse_node(node, context));
             } else {
                 items.push("${".into());
                 items.push(PrintItem::FinishIgnoringIndent);
                 items.push(PrintItem::PossibleNewLine);
                 items.push(conditions::single_indent_if_start_of_line().into());
-                items.extend(parse_node(node, context));
+                items.push(parse_node(node, context));
                 items.push(PrintItem::PossibleNewLine);
                 items.push(conditions::single_indent_if_start_of_line().into());
                 items.push("}".into());
@@ -1634,7 +1666,7 @@ fn parse_template_literal<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>
         }
         items.push("`".into());
         items.push(PrintItem::FinishIgnoringIndent);
-        items
+        items.into()
     });
 
     fn get_nodes<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>) -> Vec<Node<'a>> {
@@ -1675,21 +1707,21 @@ fn parse_template_literal<'a>(quasis: &'a Vec<TplElement>, exprs: &Vec<&'a Expr>
     }
 }
 
-fn parse_type_assertion<'a>(node: &'a TsTypeAssertion, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_assertion<'a>(node: &'a TsTypeAssertion, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("<".into());
-    items.extend(parse_node((&node.type_ann).into(), context));
+    items.push(parse_node((&node.type_ann).into(), context));
     items.push(">".into());
     if context.config.type_assertion_space_before_expression { items.push(" ".into()); }
-    items.extend(parse_node((&node.expr).into(), context));
-    items
+    items.push(parse_node((&node.expr).into(), context));
+    items.into()
 }
 
-fn parse_unary_expr<'a>(node: &'a UnaryExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_unary_expr<'a>(node: &'a UnaryExpr, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.insert(0, get_operator_text(node.op).into());
-    items.extend(parse_node((&node.arg).into(), context));
-    return items;
+    items.push(parse_node((&node.arg).into(), context));
+    return items.into();
 
     fn get_operator_text<'a>(op: UnaryOp) -> &'a str {
         match op {
@@ -1704,15 +1736,16 @@ fn parse_unary_expr<'a>(node: &'a UnaryExpr, context: &mut Context<'a>) -> Vec<P
     }
 }
 
-fn parse_update_expr<'a>(node: &'a UpdateExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.arg).into(), context);
+fn parse_update_expr<'a>(node: &'a UpdateExpr, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_node((&node.arg).into(), context));
     let operator_text = get_operator_text(node.op);
     if node.prefix {
         items.insert(0, operator_text.into());
     } else {
         items.push(operator_text.into());
     }
-    return items;
+    return items.into();
 
     fn get_operator_text<'a>(operator: UpdateOp) -> &'a str {
         match operator {
@@ -1722,81 +1755,81 @@ fn parse_update_expr<'a>(node: &'a UpdateExpr, context: &mut Context<'a>) -> Vec
     }
 }
 
-fn parse_yield_expr<'a>(node: &'a YieldExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_yield_expr<'a>(node: &'a YieldExpr, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("yield".into());
     if node.delegate { items.push("*".into()); }
     if let Some(arg) = &node.arg {
         items.push(" ".into());
-        items.extend(parse_node(arg.into(), context));
+        items.push(parse_node(arg.into(), context));
     }
-    items
+    items.into()
 }
 
 /* exports */
 
-fn parse_export_named_specifier<'a>(node: &'a NamedExportSpecifier, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_export_named_specifier<'a>(node: &'a NamedExportSpecifier, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
-    items.extend(parse_node((&node.orig).into(), context));
+    items.push(parse_node((&node.orig).into(), context));
     if let Some(exported) = &node.exported {
         items.push(PrintItem::SpaceOrNewLine);
         items.push(conditions::indent_if_start_of_line({
             let mut items = Vec::new();
             items.push("as ".into());
-            items.extend(parse_node(exported.into(), context));
-            items
+            items.push(parse_node(exported.into(), context));
+            items.into()
         }).into());
     }
 
-    items
+    items.into()
 }
 
 /* imports */
 
-fn parse_import_named_specifier<'a>(node: &'a ImportSpecific, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_import_named_specifier<'a>(node: &'a ImportSpecific, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     if let Some(imported) = &node.imported {
-        items.extend(parse_node(imported.into(), context));
+        items.push(parse_node(imported.into(), context));
         items.push(PrintItem::SpaceOrNewLine);
         items.push(conditions::indent_if_start_of_line({
             let mut items = Vec::new();
             items.push("as ".into());
-            items.extend(parse_node((&node.local).into(), context));
-            items
+            items.push(parse_node((&node.local).into(), context));
+            items.into()
         }).into());
     } else {
-        items.extend(parse_node((&node.local).into(), context));
+        items.push(parse_node((&node.local).into(), context));
     }
 
-    items
+    items.into()
 }
 
-fn parse_import_namespace_specifier<'a>(node: &'a ImportStarAs, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_import_namespace_specifier<'a>(node: &'a ImportStarAs, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("* as ".into());
-    items.extend(parse_node((&node.local).into(), context));
-    return items;
+    items.push(parse_node((&node.local).into(), context));
+    return items.into();
 }
 
-fn parse_external_module_ref<'a>(node: &'a TsExternalModuleRef, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_external_module_ref<'a>(node: &'a TsExternalModuleRef, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("require".into());
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&context.token_finder.get_first_open_paren_token_within(&node.span), &node.expr, context);
-    items.extend(wrap_in_parens(parse_node((&node.expr).into(), context), use_new_lines));
-    return items;
+    items.push(wrap_in_parens(parse_node((&node.expr).into(), context), use_new_lines));
+    return items.into();
 }
 
 /* interface / type element */
 
-fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let start_info = Info::new("startCallSignature");
 
     items.push(start_info.clone().into());
-    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
-    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
+    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.call_signature_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -1807,18 +1840,18 @@ fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Co
     }, context));
     if context.config.call_signature_semi_colon { items.push(";".into()); }
 
-    return items;
+    return items.into();
 }
 
-fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let start_info = Info::new("startConstructSignature");
 
     items.push(start_info.clone().into());
     items.push("new".into());
     if context.config.construct_signature_space_after_new_keyword { items.push(" ".into()); }
-    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
-    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
+    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.construct_signature_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -1829,25 +1862,25 @@ fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, contex
     }, context));
     if context.config.construct_signature_semi_colon { items.push(";".into()); }
 
-    return items;
+    return items.into();
 }
 
-fn parse_index_signature<'a>(node: &'a TsIndexSignature, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_index_signature<'a>(node: &'a TsIndexSignature, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     if node.readonly { items.push("readonly ".into()); }
 
     // todo: this should do something similar to the other declarations here (the ones with customCloseParen)
     items.push("[".into());
-    items.extend(parse_node(node.params.iter().next().expect("Expected the index signature to have one parameter.").into(), context));
+    items.push(parse_node(node.params.iter().next().expect("Expected the index signature to have one parameter.").into(), context));
     items.push("]".into());
-    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
     if context.config.index_signature_semi_colon { items.push(";".into()); }
 
-    return items;
+    return items.into();
 }
 
-fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>) -> PrintItem {
     let start_header_info = get_parent_info(context);
 
     return parse_membered_body(ParseMemberedBodyOptions {
@@ -1871,18 +1904,18 @@ fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>
     }
 }
 
-fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let start_info = Info::new("startMethodSignature");
     items.push(start_info.clone().into());
 
     if node.computed { items.push("[".into()); }
-    items.extend(parse_node((&node.key).into(), context));
+    items.push(parse_node((&node.key).into(), context));
     if node.computed { items.push("]".into()); }
     if node.optional { items.push("?".into()); }
-    if let Some(type_params) = &node.type_params { items.extend(parse_node(type_params.into(), context)); }
+    if let Some(type_params) = &node.type_params { items.push(parse_node(type_params.into(), context)); }
 
-    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.method_signature_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -1894,34 +1927,34 @@ fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context
 
     if context.config.method_signature_semi_colon { items.push(";".into()); }
 
-    return items;
+    return items.into();
 }
 
-fn parse_property_signature<'a>(node: &'a TsPropertySignature, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_property_signature<'a>(node: &'a TsPropertySignature, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if node.readonly { items.push("readonly ".into()); }
     if node.computed { items.push("[".into()); }
-    items.extend(parse_node((&node.key).into(), context));
+    items.push(parse_node((&node.key).into(), context));
     if node.computed { items.push("]".into()); }
     if node.optional { items.push("?".into()); }
-    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
 
     if let Some(init) = &node.init {
         items.push(PrintItem::SpaceOrNewLine);
         items.push(conditions::indent_if_start_of_line({
             let mut items = Vec::new();
             items.push("= ".into());
-            items.extend(parse_node(init.into(), context));
-            items
+            items.push(parse_node(init.into(), context));
+            items.into()
         }).into());
     }
 
     if context.config.property_signature_semi_colon { items.push(";".into()); }
 
-    return items;
+    return items.into();
 }
 
-fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> PrintItem {
     return parse_object_like_node(ParseObjectLikeNodeOptions {
         node_span: node.span,
         members: node.members.iter().map(|m| m.into()).collect(),
@@ -1931,35 +1964,35 @@ fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> Vec<Pri
 
 /* jsx */
 
-fn parse_jsx_attribute<'a>(node: &'a JSXAttr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_attribute<'a>(node: &'a JSXAttr, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.name).into(), context));
+    items.push(parse_node((&node.name).into(), context));
     if let Some(value) = &node.value {
         items.push("=".into());
         let surround_with_braces = context.token_finder.get_previous_token_if_open_brace(value).is_some();
         let parsed_value = parse_node(value.into(), context);
-        items.extend(if surround_with_braces {
+        items.push(if surround_with_braces {
             parse_as_jsx_expr_container(parsed_value, context)
         } else {
             parsed_value
         });
     }
-    return items;
+    return items.into();
 }
 
-fn parse_jsx_closing_element<'a>(node: &'a JSXClosingElement, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_closing_element<'a>(node: &'a JSXClosingElement, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("</".into());
-    items.extend(parse_node((&node.name).into(), context));
+    items.push(parse_node((&node.name).into(), context));
     items.push(">".into());
-    return items;
+    return items.into();
 }
 
-fn parse_jsx_closing_fragment<'a>(_: &'a JSXClosingFragment, _: &mut Context<'a>) -> Vec<PrintItem> {
-    vec!["</>".into()]
+fn parse_jsx_closing_fragment<'a>(_: &'a JSXClosingFragment, _: &mut Context<'a>) -> PrintItem {
+    "</>".into()
 }
 
-fn parse_jsx_element<'a>(node: &'a JSXElement, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_element<'a>(node: &'a JSXElement, context: &mut Context<'a>) -> PrintItem {
     if let Some(closing) = &node.closing {
         parse_jsx_with_opening_and_closing(ParseJsxWithOpeningAndClosingOptions {
             opening_element: (&node.opening).into(),
@@ -1971,11 +2004,11 @@ fn parse_jsx_element<'a>(node: &'a JSXElement, context: &mut Context<'a>) -> Vec
     }
 }
 
-fn parse_jsx_empty_expr<'a>(node: &'a JSXEmptyExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
-    parse_comment_collection(get_jsx_empty_expr_comments(node, context), None, context)
+fn parse_jsx_empty_expr<'a>(node: &'a JSXEmptyExpr, context: &mut Context<'a>) -> PrintItem {
+    parse_comment_collection(get_jsx_empty_expr_comments(node, context), None, context).unwrap_or(vec![].into())
 }
 
-fn parse_jsx_expr_container<'a>(node: &'a JSXExprContainer, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_expr_container<'a>(node: &'a JSXExprContainer, context: &mut Context<'a>) -> PrintItem {
     // Don't send JSX empty expressions to parse_node because it will not handle comments
     // the way they should be specifically handled for empty expressions.
     let expr_items = match &node.expr {
@@ -1986,20 +2019,20 @@ fn parse_jsx_expr_container<'a>(node: &'a JSXExprContainer, context: &mut Contex
     parse_as_jsx_expr_container(expr_items, context)
 }
 
-fn parse_as_jsx_expr_container(parsed_node: Vec<PrintItem>, context: &mut Context) -> Vec<PrintItem> {
+fn parse_as_jsx_expr_container(parsed_node: PrintItem, context: &mut Context) -> PrintItem {
     let surround_with_space = context.config.jsx_expression_container_space_surrounding_expression;
     let mut items = Vec::new();
 
     items.push("{".into());
     if surround_with_space { items.push(" ".into()); }
-    items.extend(parsed_node);
+    items.push(parsed_node);
     if surround_with_space { items.push(" ".into()); }
     items.push("}".into());
 
-    return items;
+    return items.into();
 }
 
-fn parse_jsx_fragment<'a>(node: &'a JSXFragment, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_fragment<'a>(node: &'a JSXFragment, context: &mut Context<'a>) -> PrintItem {
     parse_jsx_with_opening_and_closing(ParseJsxWithOpeningAndClosingOptions {
         opening_element: (&node.opening).into(),
         closing_element: (&node.closing).into(),
@@ -2007,34 +2040,34 @@ fn parse_jsx_fragment<'a>(node: &'a JSXFragment, context: &mut Context<'a>) -> V
     }, context)
 }
 
-fn parse_jsx_member_expr<'a>(node: &'a JSXMemberExpr, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_member_expr<'a>(node: &'a JSXMemberExpr, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.obj).into(), context));
+    items.push(parse_node((&node.obj).into(), context));
     items.push(".".into());
-    items.extend(parse_node((&node.prop).into(), context));
-    return items;
+    items.push(parse_node((&node.prop).into(), context));
+    return items.into();
 }
 
-fn parse_jsx_namespaced_name<'a>(node: &'a JSXNamespacedName, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_namespaced_name<'a>(node: &'a JSXNamespacedName, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.ns).into(), context));
+    items.push(parse_node((&node.ns).into(), context));
     items.push(":".into());
-    items.extend(parse_node((&node.name).into(), context));
-    return items;
+    items.push(parse_node((&node.name).into(), context));
+    return items.into();
 }
 
-fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Context<'a>) -> PrintItem {
     let is_multi_line = get_is_multi_line(node, context);
     let start_info = Info::new("openingElementStartInfo");
     let mut items = Vec::new();
 
     items.push(start_info.clone().into());
     items.push("<".into());
-    items.extend(parse_node((&node.name).into(), context));
+    items.push(parse_node((&node.name).into(), context));
     if let Some(type_args) = &node.type_args {
-        items.extend(parse_node(type_args.into(), context));
+        items.push(parse_node(type_args.into(), context));
     }
-    items.extend(parse_attribs(&node.attrs, is_multi_line, context));
+    items.push(parse_attribs(&node.attrs, is_multi_line, context));
     if node.self_closing {
         if !is_multi_line {
             items.push(" ".into());
@@ -2044,18 +2077,18 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
         // todo: move condition to core library
         items.push(Condition::new("newlineIfHanging", ConditionProperties {
             condition: Box::new(move |condition_context| condition_resolvers::is_hanging(condition_context, &start_info, &None)),
-            true_path: Some(vec![PrintItem::NewLine]),
+            true_path: Some(PrintItem::NewLine),
             false_path: None,
         }).into());
     }
     items.push(">".into());
 
-    return items;
+    return items.into();
 
-    fn parse_attribs<'a>(attribs: &'a Vec<JSXAttrOrSpread>, is_multi_line: bool, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_attribs<'a>(attribs: &'a Vec<JSXAttrOrSpread>, is_multi_line: bool, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
         if attribs.is_empty() {
-            return items;
+            return items.into();
         }
 
         for attrib in attribs {
@@ -2079,7 +2112,7 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
             items.push(PrintItem::NewLine);
         }
 
-        return items;
+        return items.into();
     }
 
     fn get_is_multi_line(node: &JSXOpeningElement, context: &mut Context) -> bool {
@@ -2091,20 +2124,20 @@ fn parse_jsx_opening_element<'a>(node: &'a JSXOpeningElement, context: &mut Cont
     }
 }
 
-fn parse_jsx_opening_fragment<'a>(_: &'a JSXOpeningFragment, _: &mut Context<'a>) -> Vec<PrintItem> {
-    vec!["<>".into()]
+fn parse_jsx_opening_fragment<'a>(_: &'a JSXOpeningFragment, _: &mut Context<'a>) -> PrintItem {
+    "<>".into()
 }
 
-fn parse_jsx_spread_child<'a>(node: &'a JSXSpreadChild, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_spread_child<'a>(node: &'a JSXSpreadChild, context: &mut Context<'a>) -> PrintItem {
     parse_as_jsx_expr_container({
         let mut items = Vec::new();
         items.push("...".into());
-        items.extend(parse_node((&node.expr).into(), context));
-        items
+        items.push(parse_node((&node.expr).into(), context));
+        items.into()
     }, context)
 }
 
-fn parse_jsx_text<'a>(node: &'a JSXText, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_text<'a>(node: &'a JSXText, context: &mut Context<'a>) -> PrintItem {
     let lines = node.text(context).trim().lines().map(|line| line.trim_end());
     let mut past_line: Option<&str> = None;
     let mut past_past_line: Option<&str> = None;
@@ -2128,37 +2161,37 @@ fn parse_jsx_text<'a>(node: &'a JSXText, context: &mut Context<'a>) -> Vec<Print
         past_past_line = std::mem::replace(&mut past_line, Some(line));
     }
 
-    return items;
+    return items.into();
 }
 
 /* literals */
 
-fn parse_big_int_literal<'a>(node: &'a BigInt, context: &mut Context<'a>) -> Vec<PrintItem> {
-    vec![node.text(context).into()]
+fn parse_big_int_literal<'a>(node: &'a BigInt, context: &mut Context<'a>) -> PrintItem {
+    node.text(context).into()
 }
 
-fn parse_bool_literal(node: &Bool) -> Vec<PrintItem> {
-    vec![match node.value {
+fn parse_bool_literal(node: &Bool) -> PrintItem {
+    match node.value {
         true => "true",
         false => "false",
-    }.into()]
+    }.into()
 }
 
-fn parse_num_literal<'a>(node: &'a Number, context: &mut Context<'a>) -> Vec<PrintItem> {
-    vec![node.text(context).into()]
+fn parse_num_literal<'a>(node: &'a Number, context: &mut Context<'a>) -> PrintItem {
+    node.text(context).into()
 }
 
-fn parse_reg_exp_literal(node: &Regex, _: &mut Context) -> Vec<PrintItem> {
+fn parse_reg_exp_literal(node: &Regex, _: &mut Context) -> PrintItem {
     // the exp and flags should not be nodes so just ignore that (swc issue #511)
     let mut items = Vec::new();
     items.push("/".into());
     items.push((&node.exp as &str).into());
     items.push("/".into());
     items.push((&node.flags as &str).into());
-    items
+    items.into()
 }
 
-fn parse_string_literal<'a>(node: &'a Str, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_string_literal<'a>(node: &'a Str, context: &mut Context<'a>) -> PrintItem {
     return parse_raw_string(&get_string_literal_text(get_string_value(&node, context), context));
 
     fn get_string_literal_text(string_value: String, context: &mut Context) -> String {
@@ -2182,7 +2215,7 @@ fn parse_string_literal<'a>(node: &'a Str, context: &mut Context<'a>) -> Vec<Pri
 
 /* module */
 
-fn parse_module<'a>(node: &'a Module, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_module<'a>(node: &'a Module, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if let Some(shebang) = &node.shebang {
         items.push("#!".into());
@@ -2194,7 +2227,7 @@ fn parse_module<'a>(node: &'a Module, context: &mut Context<'a>) -> Vec<PrintIte
             }
         }
     }
-    items.extend(parse_statements_or_members(ParseStatementsOrMembersOptions {
+    items.push(parse_statements_or_members(ParseStatementsOrMembersOptions {
         inner_span: node.span,
         items: node.body.iter().map(|module_item| (module_item.into(), None)).collect(),
         should_use_space: None,
@@ -2202,72 +2235,75 @@ fn parse_module<'a>(node: &'a Module, context: &mut Context<'a>) -> Vec<PrintIte
         should_use_blank_line: |previous, next, context| node_helpers::has_separating_blank_line(previous, next, context),
         trailing_commas: None,
     }, context));
-    return items;
+    return items.into();
 }
 
 /* patterns */
 
-fn parse_array_pat<'a>(node: &'a ArrayPat, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_array_like_nodes(ParseArrayLikeNodesOptions {
+fn parse_array_pat<'a>(node: &'a ArrayPat, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_array_like_nodes(ParseArrayLikeNodesOptions {
         parent_span: node.span,
         elements: node.elems.iter().map(|x| x.as_ref().map(|elem| elem.into())).collect(),
         trailing_commas: context.config.array_pattern_trailing_commas,
-    }, context);
-    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    items
+    }, context));
+    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items.into()
 }
 
-fn parse_assign_pat<'a>(node: &'a AssignPat, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_assign_pat<'a>(node: &'a AssignPat, context: &mut Context<'a>) -> PrintItem {
     parser_helpers::new_line_group({
-        let mut items = parse_node((&node.left).into(), context);
+        let mut items = Vec::new();
+        items.push(parse_node((&node.left).into(), context));
         items.push(PrintItem::SpaceOrNewLine);
         items.push(conditions::indent_if_start_of_line({
             let mut items = vec!["= ".into()];
-            items.extend(parse_node((&node.right).into(), context));
-            items
+            items.push(parse_node((&node.right).into(), context));
+            items.into()
         }).into());
-        items
+        items.into()
     })
 }
 
-fn parse_assign_pat_prop<'a>(node: &'a AssignPatProp, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_assign_pat_prop<'a>(node: &'a AssignPatProp, context: &mut Context<'a>) -> PrintItem {
     return parser_helpers::new_line_group({
         let mut items = Vec::new();
-        items.extend(parse_node((&node.key).into(), context));
+        items.push(parse_node((&node.key).into(), context));
         if let Some(value) = &node.value {
             items.push(PrintItem::SpaceOrNewLine);
             items.push(conditions::indent_if_start_of_line({
                 let mut items = Vec::new();
                 items.push("= ".into());
-                items.extend(parse_node(value.into(), context));
-                items
+                items.push(parse_node(value.into(), context));
+                items.into()
             }).into());
         }
-        items
+        items.into()
     });
 }
 
-fn parse_rest_pat<'a>(node: &'a RestPat, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_rest_pat<'a>(node: &'a RestPat, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("...".into());
-    items.extend(parse_node((&node.arg).into(), context));
-    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    items
+    items.push(parse_node((&node.arg).into(), context));
+    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    items.into()
 }
 
-fn parse_object_pat<'a>(node: &'a ObjectPat, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_object_like_node(ParseObjectLikeNodeOptions {
+fn parse_object_pat<'a>(node: &'a ObjectPat, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+    items.push(parse_object_like_node(ParseObjectLikeNodeOptions {
         node_span: node.span,
         members: node.props.iter().map(|x| x.into()).collect(),
         trailing_commas: Some(TrailingCommas::Never),
-    }, context);
-    items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    return items;
+    }, context));
+    items.push(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
+    return items.into();
 }
 
 /* properties */
 
-fn parse_method_prop<'a>(node: &'a MethodProp, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_method_prop<'a>(node: &'a MethodProp, context: &mut Context<'a>) -> PrintItem {
     return parse_class_or_object_method(ClassOrObjectMethod {
         decorators: None,
         accessibility: None,
@@ -2318,10 +2354,10 @@ impl From<MethodKind> for ClassOrObjectMethodKind {
     }
 }
 
-fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if let Some(decorators) = node.decorators.as_ref() {
-        items.extend(parse_decorators(decorators, false, context));
+        items.push(parse_decorators(decorators, false, context));
     }
 
     let start_header_info = Info::new("methodStartHeaderInfo");
@@ -2341,12 +2377,12 @@ fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut
     }
 
     if node.is_generator { items.push("*".into()); }
-    items.extend(parse_node(node.key, context));
+    items.push(parse_node(node.key, context));
     if node.is_optional { items.push("?".into()); }
-    if let Some(type_params) = node.type_params { items.extend(parse_node(type_params, context)); }
+    if let Some(type_params) = node.type_params { items.push(parse_node(type_params, context)); }
     if get_use_space_before_parens(&node.kind, context) { items.push(" ".into()) }
 
-    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.into_iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: get_force_multi_line_parameters(&node.kind, context),
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -2358,17 +2394,17 @@ fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut
 
     if let Some(body) = node.body {
         let brace_position = get_brace_position(&node.kind, context);
-        items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+        items.push(parse_brace_separator(ParseBraceSeparatorOptions {
             brace_position: brace_position,
             open_brace_token: context.token_finder.get_first_open_brace_token_within(&body),
             start_header_info: Some(start_header_info),
         }, context));
-        items.extend(parse_node(body, context));
+        items.push(parse_node(body, context));
     } else if get_use_semi_colon(&node.kind, context) {
         items.push(";".into());
     }
 
-    return items;
+    return items.into();
 
     fn get_force_multi_line_parameters(kind: &ClassOrObjectMethodKind, context: &mut Context) -> bool {
         match kind {
@@ -2417,7 +2453,7 @@ fn accessibility_to_str(accessibility: &Accessibility) -> &str {
 
 /* statements */
 
-fn parse_block_stmt<'a>(node: &'a BlockStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_block_stmt<'a>(node: &'a BlockStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let start_statements_info = Info::new("startStatementsInfo");
     let end_statements_info = Info::new("endStatementsInfo");
@@ -2425,19 +2461,23 @@ fn parse_block_stmt<'a>(node: &'a BlockStmt, context: &mut Context<'a>) -> Vec<P
 
     items.push("{".into());
 
-    items.extend(parse_trailing_comments(&open_brace_token, context));
+    if let Some(parsed_comments) = parse_trailing_comments(&open_brace_token, context) {
+        items.push(parsed_comments);
+    }
 
     // Allow: const t = () => {}; and const t = function() {};
     let is_arrow_or_fn_expr = match context.parent().kind() { NodeKind::ArrowExpr | NodeKind::FnExpr => true, _ => false };
     if is_arrow_or_fn_expr && node.start_line(context) == node.end_line(context) && node.stmts.is_empty() && !node.leading_comments(context).peekable().peek().is_some() {
         items.push("}".into());
-        return items;
+        return items.into();
     }
 
-    items.extend(parse_first_line_trailing_comments(&node, node.stmts.get(0).map(|x| x as &dyn Spanned), context));
+    if let Some(parsed_comments) = parse_first_line_trailing_comments(&node, node.stmts.get(0).map(|x| x as &dyn Spanned), context) {
+        items.push(parsed_comments);
+    }
     items.push(PrintItem::NewLine);
     items.push(start_statements_info.clone().into());
-    items.extend(parser_helpers::with_indent(
+    items.push(parser_helpers::with_indent(
         parse_statements(node.get_inner_span(context), node.stmts.iter().map(|stmt| stmt.into()).collect(), context)
     ));
     items.push(end_statements_info.clone().into());
@@ -2446,44 +2486,44 @@ fn parse_block_stmt<'a>(node: &'a BlockStmt, context: &mut Context<'a>) -> Vec<P
             condition_resolvers::are_infos_equal(context, &start_statements_info, &end_statements_info)
         }),
         true_path: None,
-        false_path: Some(vec![PrintItem::NewLine]),
+        false_path: Some(PrintItem::NewLine),
     }).into());
     items.push("}".into());
 
-    return items;
+    return items.into();
 }
 
-fn parse_break_stmt<'a>(node: &'a BreakStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_break_stmt<'a>(node: &'a BreakStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     items.push("break".into());
     if let Some(label) = &node.label {
         items.push(" ".into());
-        items.extend(parse_node(label.into(), context));
+        items.push(parse_node(label.into(), context));
     }
     if context.config.break_statement_semi_colon {
         items.push(";".into());
     }
 
-    items
+    items.into()
 }
 
-fn parse_continue_stmt<'a>(node: &'a ContinueStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_continue_stmt<'a>(node: &'a ContinueStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     items.push("continue".into());
     if let Some(label) = &node.label {
         items.push(" ".into());
-        items.extend(parse_node(label.into(), context));
+        items.push(parse_node(label.into(), context));
     }
     if context.config.continue_statement_semi_colon {
         items.push(";".into());
     }
 
-    items
+    items.into()
 }
 
-fn parse_debugger_stmt<'a>(_: &'a DebuggerStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_debugger_stmt<'a>(_: &'a DebuggerStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     items.push("debugger".into());
@@ -2491,117 +2531,123 @@ fn parse_debugger_stmt<'a>(_: &'a DebuggerStmt, context: &mut Context<'a>) -> Ve
         items.push(";".into());
     }
 
-    items
+    items.into()
 }
 
-fn parse_do_while_stmt<'a>(node: &'a DoWhileStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_do_while_stmt<'a>(node: &'a DoWhileStmt, context: &mut Context<'a>) -> PrintItem {
     // the braces are technically optional on do while statements
     let mut items = Vec::new();
     items.push("do".into());
-    items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+    items.push(parse_brace_separator(ParseBraceSeparatorOptions {
         brace_position: context.config.do_while_statement_brace_position,
         open_brace_token: if let Stmt::Block(_) = &*node.body { context.token_finder.get_first_open_brace_token_within(&node) } else { None },
         start_header_info: None,
     }, context));
-    items.extend(parse_node((&node.body).into(), context));
+    items.push(parse_node((&node.body).into(), context));
     items.push(" while".into());
     if context.config.do_while_statement_space_after_while_keyword {
         items.push(" ".into());
     }
-    items.extend(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
+    items.push(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
     if context.config.do_while_statement_semi_colon {
         items.push(";".into());
     }
-    return items;
+    return items.into();
 }
 
-fn parse_export_all<'a>(node: &'a ExportAll, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_export_all<'a>(node: &'a ExportAll, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("export * from ".into());
-    items.extend(parse_node((&node.src).into(), context));
+    items.push(parse_node((&node.src).into(), context));
 
     if context.config.export_all_declaration_semi_colon {
         items.push(";".into());
     }
 
-    items
+    items.into()
 }
 
-fn parse_empty_stmt(_: &EmptyStmt, _: &mut Context) -> Vec<PrintItem> {
-    vec![";".into()]
+fn parse_empty_stmt(_: &EmptyStmt, _: &mut Context) -> PrintItem {
+    ";".into()
 }
 
-fn parse_export_assignment<'a>(node: &'a TsExportAssignment, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_export_assignment<'a>(node: &'a TsExportAssignment, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     items.push("export = ".into());
-    items.extend(parse_node((&node.expr).into(), context));
+    items.push(parse_node((&node.expr).into(), context));
     if context.config.export_assignment_semi_colon {
         items.push(";".into());
     }
 
-    items
+    items.into()
 }
 
-fn parse_namespace_export<'a>(node: &'a TsNamespaceExportDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_namespace_export<'a>(node: &'a TsNamespaceExportDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("export as namespace ".into());
-    items.extend(parse_node((&node.id).into(), context));
+    items.push(parse_node((&node.id).into(), context));
 
     if context.config.namespace_export_declaration_semi_colon {
         items.push(";".into());
     }
 
-    items
+    items.into()
 }
 
-fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItem {
     if context.config.expression_statement_semi_colon {
         return parse_inner(&stmt, context);
     } else {
         return parse_for_prefix_semi_colon_insertion(&stmt, context);
     }
 
-    fn parse_inner<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_inner<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
-        items.extend(parse_node((&stmt.expr).into(), context));
+        items.push(parse_node((&stmt.expr).into(), context));
         if context.config.expression_statement_semi_colon {
             items.push(";".into());
         }
-        return items;
+        return items.into();
     }
 
-    fn parse_for_prefix_semi_colon_insertion<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
-        let mut parsed_node = parse_inner(&stmt, context);
-        if should_add_semi_colon(&parsed_node).unwrap_or(false) {
-            parsed_node.insert(0, ";".into());
-        }
-        return parsed_node;
+    fn parse_for_prefix_semi_colon_insertion<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItem {
+        let parsed_node = parse_inner(&stmt, context);
+        return if should_add_semi_colon(&parsed_node).unwrap_or(false) {
+            vec![";".into(), parsed_node].into()
+        } else {
+            parsed_node
+        };
 
-        fn should_add_semi_colon(items: &Vec<PrintItem>) -> Option<bool> {
-            for item in items {
-                match item {
-                    PrintItem::String(value) => {
-                        if let Some(c) = value.chars().next() {
-                            return utils::is_prefix_semi_colon_insertion_char(c).into();
+        fn should_add_semi_colon(item: &PrintItem) -> Option<bool> {
+            match item {
+                PrintItem::Items(items) => {
+                    for item in items.iter() {
+                        if let Some(result) = should_add_semi_colon(item) {
+                            return result.into();
                         }
-                    },
-                    PrintItem::Condition(condition) => {
-                        // It's an assumption here that th etrue and false paths of the
-                        // condition will both contain the same text to look for.
-                        if let Some(true_path) = &condition.true_path {
-                            if let Some(result) = should_add_semi_colon(true_path) {
-                                return result.into();
-                            }
+                    }
+                },
+                PrintItem::String(value) => {
+                    if let Some(c) = value.chars().next() {
+                        return utils::is_prefix_semi_colon_insertion_char(c).into();
+                    }
+                },
+                PrintItem::Condition(condition) => {
+                    // It's an assumption here that th etrue and false paths of the
+                    // condition will both contain the same text to look for.
+                    if let Some(true_path) = &condition.true_path {
+                        if let Some(result) = should_add_semi_colon(true_path) {
+                            return result.into();
                         }
-                        if let Some(false_path) = &condition.false_path {
-                            if let Some(result) = should_add_semi_colon(false_path) {
-                                return result.into();
-                            }
+                    }
+                    if let Some(false_path) = &condition.false_path {
+                        if let Some(result) = should_add_semi_colon(false_path) {
+                            return result.into();
                         }
-                    },
-                    _ => { /* do nothing */ },
-                }
+                    }
+                },
+                _ => { /* do nothing */ },
             }
 
             None
@@ -2609,7 +2655,7 @@ fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> Vec<Pri
     }
 }
 
-fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> PrintItem {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
     let mut items = Vec::new();
@@ -2618,7 +2664,7 @@ fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> Vec<Print
     if context.config.for_statement_space_after_for_keyword {
         items.push(" ".into());
     }
-    items.extend(parse_node_in_parens({
+    items.push(parse_node_in_parens({
         if let Some(init) = &node.init {
             init.into()
         } else {
@@ -2627,36 +2673,32 @@ fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> Vec<Print
     }, |context| {
         let mut items = Vec::new();
         let separator_after_semi_colons = if context.config.for_statement_space_after_semi_colons { PrintItem::SpaceOrNewLine } else { PrintItem::PossibleNewLine };
-        items.extend(parser_helpers::new_line_group({
+        items.push(parser_helpers::new_line_group({
             let mut items = Vec::new();
             if let Some(init) = &node.init {
-                items.extend(parse_node(init.into(), context));
+                items.push(parse_node(init.into(), context));
             }
             items.push(";".into());
-            items
+            items.into()
         }));
         items.push(separator_after_semi_colons.clone());
         items.push(conditions::indent_if_start_of_line({
             let mut items = Vec::new();
             if let Some(test) = &node.test {
-                items.extend(parse_node(test.into(), context));
+                items.push(parse_node(test.into(), context));
             }
             items.push(";".into());
-            items
+            items.into()
         }).into());
         items.push(separator_after_semi_colons);
-        items.push(conditions::indent_if_start_of_line({
-            if let Some(update) = &node.update {
-                parse_node(update.into(), context)
-            } else {
-                vec![]
-            }
-        }).into());
-        items
+        if let Some(update) = &node.update {
+            items.push(conditions::indent_if_start_of_line(parse_node(update.into(), context)).into());
+        }
+        items.into()
     }, context));
     items.push(end_header_info.clone().into());
 
-    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: context.config.for_statement_use_braces,
@@ -2668,10 +2710,10 @@ fn parse_for_stmt<'a>(node: &'a ForStmt, context: &mut Context<'a>) -> Vec<Print
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
 
-    return items;
+    return items.into();
 }
 
-fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> PrintItem {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
     let mut items = Vec::new();
@@ -2680,21 +2722,21 @@ fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> Vec<
     if context.config.for_in_statement_space_after_for_keyword {
         items.push(" ".into());
     }
-    items.extend(parse_node_in_parens((&node.left).into(), |context| {
+    items.push(parse_node_in_parens((&node.left).into(), |context| {
         let mut items = Vec::new();
-        items.extend(parse_node((&node.left).into(), context));
+        items.push(parse_node((&node.left).into(), context));
         items.push(PrintItem::SpaceOrNewLine);
         items.push(conditions::indent_if_start_of_line({
             let mut items = Vec::new();
             items.push("in ".into());
-            items.extend(parse_node((&node.right).into(), context));
-            items
+            items.push(parse_node((&node.right).into(), context));
+            items.into()
         }).into());
-        items
+        items.into()
     }, context));
     items.push(end_header_info.clone().into());
 
-    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: context.config.for_in_statement_use_braces,
@@ -2706,10 +2748,10 @@ fn parse_for_in_stmt<'a>(node: &'a ForInStmt, context: &mut Context<'a>) -> Vec<
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
 
-    return items;
+    return items.into();
 }
 
-fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> PrintItem {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
     let mut items = Vec::new();
@@ -2719,24 +2761,24 @@ fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> Vec<
         items.push(" ".into());
     }
     if let Some(await_token) = &node.await_token {
-        items.extend(parse_node(await_token.into(), context));
+        items.push(parse_node(await_token.into(), context));
         items.push(" ".into());
     }
-    items.extend(parse_node_in_parens((&node.left).into(), |context| {
+    items.push(parse_node_in_parens((&node.left).into(), |context| {
         let mut items = Vec::new();
-        items.extend(parse_node((&node.left).into(), context));
+        items.push(parse_node((&node.left).into(), context));
         items.push(PrintItem::SpaceOrNewLine);
         items.push(conditions::indent_if_start_of_line({
             let mut items = Vec::new();
             items.push("of ".into());
-            items.extend(parse_node((&node.right).into(), context));
-            items
+            items.push(parse_node((&node.right).into(), context));
+            items.into()
         }).into());
-        items
+        items.into()
     }, context));
     items.push(end_header_info.clone().into());
 
-    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: context.config.for_of_statement_use_braces,
@@ -2748,10 +2790,10 @@ fn parse_for_of_stmt<'a>(node: &'a ForOfStmt, context: &mut Context<'a>) -> Vec<
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
 
-    return items;
+    return items.into();
 }
 
-fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let cons = &*node.cons;
     let cons_span = cons.span();
@@ -2763,8 +2805,8 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> Vec<PrintIt
             items.push("if".into());
             if context.config.if_statement_space_after_if_keyword { items.push(" ".into()); }
             let test = &*node.test;
-            items.extend(parse_node_in_parens(test.into(), |context| parse_node(test.into(), context), context));
-            items
+            items.push(parse_node_in_parens(test.into(), |context| parse_node(test.into(), context), context));
+            items.into()
         },
         use_braces: context.config.if_statement_use_braces,
         brace_position: context.config.if_statement_brace_position,
@@ -2772,7 +2814,7 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> Vec<PrintIt
         requires_braces_condition: context.take_if_stmt_last_brace_condition(),
     }, context);
 
-    items.extend(result.parsed_node);
+    items.push(result.parsed_node);
 
     if let Some(alt) = &node.alt {
         if let Stmt::If(alt_alt) = &**alt {
@@ -2781,12 +2823,16 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> Vec<PrintIt
             }
         }
 
-        items.extend(parse_control_flow_separator(context.config.if_statement_next_control_flow_position, &cons_span, "else", context));
+        items.push(parse_control_flow_separator(context.config.if_statement_next_control_flow_position, &cons_span, "else", context));
 
         // parse the leading comments before the else keyword
         let else_keyword = context.token_finder.get_first_else_keyword_within(&Span::new(cons_span.hi(), alt.lo(), Default::default())).expect("Expected to find an else keyword.");
-        items.extend(parse_leading_comments(else_keyword, context));
-        items.extend(parse_leading_comments(&alt, context));
+        if let Some(parsed_comments) = parse_leading_comments(else_keyword, context) {
+            items.push(parsed_comments);
+        }
+        if let Some(parsed_comments) = parse_leading_comments(&alt, context) {
+            items.push(parsed_comments);
+        }
 
         let start_else_header_info = Info::new("startElseHeader");
         items.push(start_else_header_info.clone().into());
@@ -2794,9 +2840,9 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> Vec<PrintIt
 
         if let Stmt::If(alt) = &**alt {
             items.push(" ".into());
-            items.extend(parse_node(alt.into(), context));
+            items.push(parse_node(alt.into(), context));
         } else {
-            items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+            items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
                 parent: &node.span,
                 body_node: alt.into(),
                 use_braces: context.config.if_statement_use_braces,
@@ -2810,12 +2856,12 @@ fn parse_if_stmt<'a>(node: &'a IfStmt, context: &mut Context<'a>) -> Vec<PrintIt
         }
     }
 
-    return items;
+    return items.into();
 }
 
-fn parse_labeled_stmt<'a>(node: &'a LabeledStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_labeled_stmt<'a>(node: &'a LabeledStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.label).into(), context));
+    items.push(parse_node((&node.label).into(), context));
     items.push(":".into());
 
     // not bothering to make this configurable, because who uses labeled statements?
@@ -2825,29 +2871,29 @@ fn parse_labeled_stmt<'a>(node: &'a LabeledStmt, context: &mut Context<'a>) -> V
         PrintItem::NewLine
     });
 
-    items.extend(parse_node((&node.body).into(), context));
+    items.push(parse_node((&node.body).into(), context));
 
-    return items;
+    return items.into();
 }
 
-fn parse_return_stmt<'a>(node: &'a ReturnStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_return_stmt<'a>(node: &'a ReturnStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("return".into());
     if let Some(arg) = &node.arg {
         items.push(" ".into());
-        items.extend(parse_node(arg.into(), context));
+        items.push(parse_node(arg.into(), context));
     }
     if context.config.return_statement_semi_colon { items.push(";".into()); }
-    return items;
+    return items.into();
 }
 
-fn parse_switch_stmt<'a>(node: &'a SwitchStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_switch_stmt<'a>(node: &'a SwitchStmt, context: &mut Context<'a>) -> PrintItem {
     let start_header_info = Info::new("startHeader");
     let mut items = Vec::new();
     items.push(start_header_info.clone().into());
     items.push("switch ".into());
-    items.extend(parse_node_in_parens((&node.discriminant).into(), |context| parse_node((&node.discriminant).into(), context), context));
-    items.extend(parse_membered_body(ParseMemberedBodyOptions {
+    items.push(parse_node_in_parens((&node.discriminant).into(), |context| parse_node((&node.discriminant).into(), context), context));
+    items.push(parse_membered_body(ParseMemberedBodyOptions {
         span: node.span,
         members: node.cases.iter().map(|x| x.into()).collect(),
         start_header_info: Some(start_header_info),
@@ -2855,10 +2901,10 @@ fn parse_switch_stmt<'a>(node: &'a SwitchStmt, context: &mut Context<'a>) -> Vec
         should_use_blank_line: |_, _, _| false,
         trailing_commas: None,
     }, context));
-    return items;
+    return items.into();
 }
 
-fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> PrintItem {
     let block_stmt_body = get_block_stmt_body(&node);
     let start_header_info = Info::new("switchCaseStartHeader");
     let mut items = Vec::new();
@@ -2872,25 +2918,27 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Vec
 
     if let Some(test) = &node.test {
         items.push("case ".into());
-        items.extend(parse_node(test.into(), context));
+        items.push(parse_node(test.into(), context));
         items.push(":".into());
     } else {
         items.push("default:".into());
     }
 
-    items.extend(parse_first_line_trailing_comments(&node.span, node.cons.get(0).map(|x| x as &dyn Spanned), context));
+    if let Some(parsed_comments) = parse_first_line_trailing_comments(&node.span, node.cons.get(0).map(|x| x as &dyn Spanned), context) {
+        items.push(parsed_comments);
+    }
     let parsed_trailing_comments = parse_trailing_comments_for_case(node.span, &block_stmt_body, context);
     if !node.cons.is_empty() {
         if let Some(block_stmt_body) = block_stmt_body {
-            items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+            items.push(parse_brace_separator(ParseBraceSeparatorOptions {
                 brace_position: context.config.switch_case_brace_position,
                 open_brace_token: context.token_finder.get_first_open_brace_token_within(&block_stmt_body),
                 start_header_info: None,
             }, context));
-            items.extend(parse_node(node.cons.iter().next().unwrap().into(), context));
+            items.push(parse_node(node.cons.iter().next().unwrap().into(), context));
         } else {
             items.push(PrintItem::NewLine);
-            items.extend(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
+            items.push(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
                 inner_span: Span::new(colon_token.hi(), node.span.hi(), Default::default()),
                 items: node.cons.iter().map(|node| (node.into(), None)).collect(),
                 should_use_space: None,
@@ -2901,9 +2949,9 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Vec
         }
     }
 
-    items.extend(parsed_trailing_comments);
+    items.push(parsed_trailing_comments);
 
-    return items;
+    return items.into();
 
     fn get_block_stmt_body(node: &SwitchCase) -> Option<Span> {
         let first_cons = node.cons.get(0);
@@ -2915,7 +2963,7 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Vec
         return None;
     }
 
-    fn parse_trailing_comments_for_case<'a>(node_span: Span, block_stmt_body: &Option<Span>, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_trailing_comments_for_case<'a>(node_span: Span, block_stmt_body: &Option<Span>, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
         // parse the trailing comments as statements
         let trailing_comments = get_trailing_comments_as_statements(&node_span, context);
@@ -2930,7 +2978,7 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Vec
                     is_equal_indent = is_equal_indent || comment.start_column(context) <= last_node.start_column(context);
                     let parsed_comment = parse_comment_based_on_last_node(&comment, &Some(&last_node), context);
 
-                    items.extend(if !is_last_case && is_equal_indent {
+                    items.push(if !is_last_case && is_equal_indent {
                         parsed_comment
                     } else {
                         parser_helpers::with_indent(parsed_comment)
@@ -2939,53 +2987,53 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Vec
                 }
             }
         }
-        return items;
+        return items.into();
     }
 }
 
-fn parse_throw_stmt<'a>(node: &'a ThrowStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_throw_stmt<'a>(node: &'a ThrowStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("throw ".into());
-    items.extend(parse_node((&node.arg).into(), context));
+    items.push(parse_node((&node.arg).into(), context));
     if context.config.throw_statement_semi_colon { items.push(";".into()); }
-    return items;
+    return items.into();
 }
 
-fn parse_try_stmt<'a>(node: &'a TryStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_try_stmt<'a>(node: &'a TryStmt, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let brace_position = context.config.try_statement_brace_position;
     let next_control_flow_position = context.config.try_statement_next_control_flow_position;
     let mut last_block_span = node.block.span;
 
     items.push("try".into());
-    items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+    items.push(parse_brace_separator(ParseBraceSeparatorOptions {
         brace_position: brace_position,
         open_brace_token: context.token_finder.get_first_open_brace_token_within(&node.block),
         start_header_info: None,
     }, context));
-    items.extend(parse_node((&node.block).into(), context));
+    items.push(parse_node((&node.block).into(), context));
 
     if let Some(handler) = &node.handler {
-        items.extend(parse_control_flow_separator(next_control_flow_position, &last_block_span, "catch", context));
+        items.push(parse_control_flow_separator(next_control_flow_position, &last_block_span, "catch", context));
         last_block_span = handler.span;
-        items.extend(parse_node(handler.into(), context));
+        items.push(parse_node(handler.into(), context));
     }
 
     if let Some(finalizer) = &node.finalizer {
-        items.extend(parse_control_flow_separator(next_control_flow_position, &last_block_span, "finally", context));
+        items.push(parse_control_flow_separator(next_control_flow_position, &last_block_span, "finally", context));
         items.push("finally".into());
-        items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+        items.push(parse_brace_separator(ParseBraceSeparatorOptions {
             brace_position: brace_position,
             open_brace_token: context.token_finder.get_first_open_brace_token_within(&finalizer),
             start_header_info: None,
         }, context));
-        items.extend(parse_node(finalizer.into(), context));
+        items.push(parse_node(finalizer.into(), context));
     }
 
-    return items;
+    return items.into();
 }
 
-fn parse_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if node.declare { items.push("declare ".into()); }
     items.push(match node.kind {
@@ -3005,7 +3053,7 @@ fn parse_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> Vec<Print
 
     if requires_semi_colon(&node.span, context) { items.push(";".into()); }
 
-    return items;
+    return items.into();
 
     fn requires_semi_colon(var_decl_span: &Span, context: &mut Context) -> bool {
         let parent = context.parent();
@@ -3018,18 +3066,20 @@ fn parse_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> Vec<Print
     }
 }
 
-fn parse_var_declarator<'a>(node: &'a VarDeclarator, context: &mut Context<'a>) -> Vec<PrintItem> {
-    let mut items = parse_node((&node.name).into(), context);
+fn parse_var_declarator<'a>(node: &'a VarDeclarator, context: &mut Context<'a>) -> PrintItem {
+    let mut items = Vec::new();
+
+    items.push(parse_node((&node.name).into(), context));
 
     if let Some(init) = &node.init {
         items.push(" = ".into());
-        items.extend(parse_node(init.into(), context));
+        items.push(parse_node(init.into(), context));
     }
 
-    items
+    items.into()
 }
 
-fn parse_while_stmt<'a>(node: &'a WhileStmt, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_while_stmt<'a>(node: &'a WhileStmt, context: &mut Context<'a>) -> PrintItem {
     let start_header_info = Info::new("startHeader");
     let end_header_info = Info::new("endHeader");
     let mut items = Vec::new();
@@ -3038,9 +3088,9 @@ fn parse_while_stmt<'a>(node: &'a WhileStmt, context: &mut Context<'a>) -> Vec<P
     if context.config.while_statement_space_after_while_keyword {
         items.push(" ".into());
     }
-    items.extend(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
+    items.push(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
     items.push(end_header_info.clone().into());
-    items.extend(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
+    items.push(parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: &node.span,
         body_node: (&node.body).into(),
         use_braces: context.config.while_statement_use_braces,
@@ -3051,38 +3101,38 @@ fn parse_while_stmt<'a>(node: &'a WhileStmt, context: &mut Context<'a>) -> Vec<P
         start_header_info: Some(start_header_info),
         end_header_info: Some(end_header_info),
     }, context).parsed_node);
-    return items;
+    return items.into();
 }
 
 /* types */
 
-fn parse_array_type<'a>(node: &'a TsArrayType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_array_type<'a>(node: &'a TsArrayType, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.elem_type).into(), context));
+    items.push(parse_node((&node.elem_type).into(), context));
     items.push("[]".into());
-    return items;
+    return items.into();
 }
 
-fn parse_conditional_type<'a>(node: &'a TsConditionalType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_conditional_type<'a>(node: &'a TsConditionalType, context: &mut Context<'a>) -> PrintItem {
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&node.check_type, &node.false_type, context);
     let is_parent_conditional_type = context.parent().kind() == NodeKind::TsConditionalType;
     let mut items = Vec::new();
 
     // main area
-    items.extend(parser_helpers::new_line_group(parse_node((&node.check_type).into(), context)));
+    items.push(parser_helpers::new_line_group(parse_node((&node.check_type).into(), context)));
     items.push(PrintItem::SpaceOrNewLine);
     items.push(conditions::indent_if_start_of_line({
         let mut items = Vec::new();
         items.push("extends ".into());
-        items.extend(parser_helpers::new_line_group(parse_node((&node.extends_type).into(), context)));
-        items
+        items.push(parser_helpers::new_line_group(parse_node((&node.extends_type).into(), context)));
+        items.into()
     }).into());
     items.push(PrintItem::SpaceOrNewLine);
     items.push(conditions::indent_if_start_of_line({
         let mut items = Vec::new();
         items.push("? ".into());
-        items.extend(parser_helpers::new_line_group(parse_node((&node.true_type).into(), context)));
-        items
+        items.push(parser_helpers::new_line_group(parse_node((&node.true_type).into(), context)));
+        items.into()
     }).into());
 
     // false type
@@ -3091,29 +3141,29 @@ fn parse_conditional_type<'a>(node: &'a TsConditionalType, context: &mut Context
     let false_type_parsed = {
         let mut items = Vec::new();
         items.push(": ".into());
-        items.extend(parser_helpers::new_line_group(parse_node((&node.false_type).into(), context)));
-        items
+        items.push(parser_helpers::new_line_group(parse_node((&node.false_type).into(), context)));
+        items.into()
     };
 
     if is_parent_conditional_type {
-        items.extend(false_type_parsed);
+        items.push(false_type_parsed);
     } else {
         items.push(conditions::indent_if_start_of_line(false_type_parsed).into());
     }
 
-    return items;
+    return items.into();
 }
 
-fn parse_constructor_type<'a>(node: &'a TsConstructorType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_constructor_type<'a>(node: &'a TsConstructorType, context: &mut Context<'a>) -> PrintItem {
     let start_info = Info::new("startConstructorType");
     let mut items = Vec::new();
     items.push(start_info.clone().into());
     items.push("new".into());
     if context.config.constructor_type_space_after_new_keyword { items.push(" ".into()); }
     if let Some(type_params) = &node.type_params {
-        items.extend(parse_node(type_params.into(), context));
+        items.push(parse_node(type_params.into(), context));
     }
-    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.constructor_type_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -3123,21 +3173,21 @@ fn parse_constructor_type<'a>(node: &'a TsConstructorType, context: &mut Context
                 let mut items = Vec::new();
                 items.push(PrintItem::SpaceOrNewLine);
                 items.push("=> ".into());
-                items
+                items.into()
             }),
         }, context)),
     }, context));
-    return items;
+    return items.into();
 }
 
-fn parse_function_type<'a>(node: &'a TsFnType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_function_type<'a>(node: &'a TsFnType, context: &mut Context<'a>) -> PrintItem {
     let start_info = Info::new("startFunctionType");
     let mut items = Vec::new();
     items.push(start_info.clone().into());
     if let Some(type_params) = &node.type_params {
-        items.extend(parse_node(type_params.into(), context));
+        items.push(parse_node(type_params.into(), context));
     }
-    items.extend(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
+    items.push(parse_parameters_or_arguments(ParseParametersOrArgumentsOptions {
         nodes: node.params.iter().map(|node| node.into()).collect(),
         force_multi_line_when_multiple_lines: context.config.function_type_force_multi_line_parameters,
         custom_close_paren: Some(parse_close_paren_with_type(ParseCloseParenWithTypeOptions {
@@ -3147,47 +3197,47 @@ fn parse_function_type<'a>(node: &'a TsFnType, context: &mut Context<'a>) -> Vec
                 let mut items = Vec::new();
                 items.push(PrintItem::SpaceOrNewLine);
                 items.push("=> ".into());
-                Some(items)
+                Some(items.into())
             },
         }, context)),
     }, context));
-    return items;
+    return items.into();
 }
 
-fn parse_import_type<'a>(node: &'a TsImportType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_import_type<'a>(node: &'a TsImportType, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("import(".into());
-    items.extend(parse_node((&node.arg).into(), context));
+    items.push(parse_node((&node.arg).into(), context));
     items.push(")".into());
 
     if let Some(qualifier) = &node.qualifier {
         items.push(".".into());
-        items.extend(parse_node(qualifier.into(), context));
+        items.push(parse_node(qualifier.into(), context));
     }
 
     if let Some(type_args) = &node.type_args {
-        items.extend(parse_node(type_args.into(), context));
+        items.push(parse_node(type_args.into(), context));
     }
-    return items;
+    return items.into();
 }
 
-fn parse_indexed_access_type<'a>(node: &'a TsIndexedAccessType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_indexed_access_type<'a>(node: &'a TsIndexedAccessType, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.obj_type).into(), context));
+    items.push(parse_node((&node.obj_type).into(), context));
     items.push("[".into());
-    items.extend(parse_node((&node.index_type).into(), context));
+    items.push(parse_node((&node.index_type).into(), context));
     items.push("]".into());
-    return items;
+    return items.into();
 }
 
-fn parse_infer_type<'a>(node: &'a TsInferType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_infer_type<'a>(node: &'a TsInferType, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("infer ".into());
-    items.extend(parse_node((&node.type_param).into(), context));
-    return items;
+    items.push(parse_node((&node.type_param).into(), context));
+    return items.into();
 }
 
-fn parse_intersection_type<'a>(node: &'a TsIntersectionType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_intersection_type<'a>(node: &'a TsIntersectionType, context: &mut Context<'a>) -> PrintItem {
     parse_union_or_intersection_type(UnionOrIntersectionType {
         span: node.span,
         types: &node.types,
@@ -3195,11 +3245,11 @@ fn parse_intersection_type<'a>(node: &'a TsIntersectionType, context: &mut Conte
     }, context)
 }
 
-fn parse_lit_type<'a>(node: &'a TsLitType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_lit_type<'a>(node: &'a TsLitType, context: &mut Context<'a>) -> PrintItem {
     parse_node((&node.lit).into(), context)
 }
 
-fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let start_info = Info::new("startMappedType");
     let end_info = Info::new("endMappedType");
@@ -3222,7 +3272,7 @@ fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> V
             }.into());
         }
         items.push("[".into());
-        items.extend(parse_node((&node.type_param).into(), context));
+        items.push(parse_node((&node.type_param).into(), context));
         items.push("]".into());
         if let Some(optional) = node.optional {
             items.push(match optional {
@@ -3231,49 +3281,49 @@ fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> V
                 TruePlusMinus::Minus => "-?",
             }.into());
         }
-        items.extend(parse_type_annotation_with_colon_if_exists_for_type(&node.type_ann, context));
+        items.push(parse_type_annotation_with_colon_if_exists_for_type(&node.type_ann, context));
         if context.config.mapped_type_semi_colon {
             items.push(";".into());
         }
-        items
+        items.into()
     })).into());
     items.push(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_info, Some(end_info.clone())).into());
     items.push("}".into());
     items.push(end_info.into());
-    return items;
+    return items.into();
 }
 
-fn parse_optional_type<'a>(node: &'a TsOptionalType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_optional_type<'a>(node: &'a TsOptionalType, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.type_ann).into(), context));
+    items.push(parse_node((&node.type_ann).into(), context));
     items.push("?".into());
-    return items;
+    return items.into();
 }
 
-fn parse_qualified_name<'a>(node: &'a TsQualifiedName, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_qualified_name<'a>(node: &'a TsQualifiedName, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.left).into(), context));
+    items.push(parse_node((&node.left).into(), context));
     items.push(".".into());
-    items.extend(parse_node((&node.right).into(), context));
-    return items;
+    items.push(parse_node((&node.right).into(), context));
+    return items.into();
 }
 
-fn parse_parenthesized_type<'a>(node: &'a TsParenthesizedType, context: &mut Context<'a>) -> Vec<PrintItem> {
-    vec![conditions::with_indent_if_start_of_line_indented(parse_node_in_parens(
+fn parse_parenthesized_type<'a>(node: &'a TsParenthesizedType, context: &mut Context<'a>) -> PrintItem {
+    conditions::with_indent_if_start_of_line_indented(parse_node_in_parens(
         (&node.type_ann).into(),
         |context| parse_node((&node.type_ann).into(), context),
         context
-    )).into()]
+    )).into()
 }
 
-fn parse_rest_type<'a>(node: &'a TsRestType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_rest_type<'a>(node: &'a TsRestType, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("...".into());
-    items.extend(parse_node((&node.type_ann).into(), context));
-    return items;
+    items.push(parse_node((&node.type_ann).into(), context));
+    return items.into();
 }
 
-fn parse_tuple_type<'a>(node: &'a TsTupleType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_tuple_type<'a>(node: &'a TsTupleType, context: &mut Context<'a>) -> PrintItem {
     parse_array_like_nodes(ParseArrayLikeNodesOptions {
         parent_span: node.span,
         elements: node.elem_types.iter().map(|x| Some(x.into())).collect(),
@@ -3281,14 +3331,14 @@ fn parse_tuple_type<'a>(node: &'a TsTupleType, context: &mut Context<'a>) -> Vec
     }, context)
 }
 
-fn parse_type_ann<'a>(node: &'a TsTypeAnn, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_ann<'a>(node: &'a TsTypeAnn, context: &mut Context<'a>) -> PrintItem {
     parse_node((&node.type_ann).into(), context)
 }
 
-fn parse_type_param<'a>(node: &'a TsTypeParam, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_param<'a>(node: &'a TsTypeParam, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
-    items.extend(parse_node((&node.name).into(), context));
+    items.push(parse_node((&node.name).into(), context));
 
     if let Some(constraint) = &node.constraint {
         items.push(PrintItem::SpaceOrNewLine);
@@ -3299,8 +3349,8 @@ fn parse_type_param<'a>(node: &'a TsTypeParam, context: &mut Context<'a>) -> Vec
             } else {
                 "extends "
             }.into());
-            items.extend(parse_node(constraint.into(), context));
-            items
+            items.push(parse_node(constraint.into(), context));
+            items.into()
         }).into());
     }
 
@@ -3309,15 +3359,15 @@ fn parse_type_param<'a>(node: &'a TsTypeParam, context: &mut Context<'a>) -> Vec
         items.push(conditions::indent_if_start_of_line({
             let mut items = Vec::new();
             items.push("= ".into());
-            items.extend(parse_node(default.into(), context));
-            items
+            items.push(parse_node(default.into(), context));
+            items.into()
         }).into());
     }
 
-    return items;
+    return items.into();
 }
 
-fn parse_type_param_instantiation<'a>(node: TypeParamNode<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_param_instantiation<'a>(node: TypeParamNode<'a>, context: &mut Context<'a>) -> PrintItem {
     let parent_span = node.span();
     let params = node.params();
     let use_new_lines = get_use_new_lines(&parent_span, &params, context);
@@ -3325,16 +3375,16 @@ fn parse_type_param_instantiation<'a>(node: TypeParamNode<'a>, context: &mut Con
     let mut items = Vec::new();
 
     items.push("<".into());
-    items.extend(if use_new_lines {
+    items.push(if use_new_lines {
         parser_helpers::surround_with_new_lines(parsed_params)
     } else {
         parsed_params
     });
     items.push(">".into());
 
-    return items;
+    return items.into();
 
-    fn parse_parameter_list<'a>(params: Vec<Node<'a>>, use_new_lines: bool, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_parameter_list<'a>(params: Vec<Node<'a>>, use_new_lines: bool, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
         let params_count = params.len();
 
@@ -3343,16 +3393,16 @@ fn parse_type_param_instantiation<'a>(node: TypeParamNode<'a>, context: &mut Con
                 items.push(if use_new_lines { PrintItem::NewLine } else { PrintItem::SpaceOrNewLine });
             }
 
-            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node_with_inner_parse(param, context, move |mut items| {
+            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node_with_inner_parse(param, context, move |item| {
                 if i < params_count - 1 {
-                    items.push(",".into());
+                    vec![item, ",".into()].into()
+                } else {
+                    item
                 }
-
-                items
             }))).into());
         }
 
-        items
+        items.into()
     }
 
     fn get_use_new_lines(parent_span: &Span, params: &Vec<Node>, context: &mut Context) -> bool {
@@ -3366,43 +3416,43 @@ fn parse_type_param_instantiation<'a>(node: TypeParamNode<'a>, context: &mut Con
     }
 }
 
-fn parse_type_operator<'a>(node: &'a TsTypeOperator, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_operator<'a>(node: &'a TsTypeOperator, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push(match node.op {
         TsTypeOperatorOp::KeyOf => "keyof ",
         TsTypeOperatorOp::Unique => "unique ",
         TsTypeOperatorOp::ReadOnly => "readonly ",
     }.into());
-    items.extend(parse_node((&node.type_ann).into(), context));
-    return items;
+    items.push(parse_node((&node.type_ann).into(), context));
+    return items.into();
 }
 
-fn parse_type_predicate<'a>(node: &'a TsTypePredicate, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_predicate<'a>(node: &'a TsTypePredicate, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if node.asserts { items.push("asserts ".into()); }
-    items.extend(parse_node((&node.param_name).into(), context));
+    items.push(parse_node((&node.param_name).into(), context));
     items.push(" is ".into());
-    items.extend(parse_node((&node.type_ann).into(), context));
-    return items;
+    items.push(parse_node((&node.type_ann).into(), context));
+    return items.into();
 }
 
-fn parse_type_query<'a>(node: &'a TsTypeQuery, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_query<'a>(node: &'a TsTypeQuery, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     items.push("typeof ".into());
-    items.extend(parse_node((&node.expr_name).into(), context));
-    return items;
+    items.push(parse_node((&node.expr_name).into(), context));
+    return items.into();
 }
 
-fn parse_type_reference<'a>(node: &'a TsTypeRef, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_reference<'a>(node: &'a TsTypeRef, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
-    items.extend(parse_node((&node.type_name).into(), context));
+    items.push(parse_node((&node.type_name).into(), context));
     if let Some(type_params) = &node.type_params {
-        items.extend(parse_node(type_params.into(), context));
+        items.push(parse_node(type_params.into(), context));
     }
-    return items;
+    return items.into();
 }
 
-fn parse_union_type<'a>(node: &'a TsUnionType, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_union_type<'a>(node: &'a TsUnionType, context: &mut Context<'a>) -> PrintItem {
     parse_union_or_intersection_type(UnionOrIntersectionType {
         span: node.span,
         types: &node.types,
@@ -3416,7 +3466,7 @@ struct UnionOrIntersectionType<'a> {
     pub is_union: bool,
 }
 
-fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     let use_new_lines = node_helpers::get_use_new_lines_for_nodes(&node.types[0], &node.types[1], context);
     let separator = if node.is_union { "|" } else { "&" };
@@ -3442,27 +3492,29 @@ fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, conte
                 items.push(after_separator_info.clone().into());
             }
             if let Some(separator_token) = separator_token {
-                items.extend(parse_trailing_comments(&separator_token, context));
+                if let Some(parsed_comments) = parse_trailing_comments(&separator_token, context) {
+                    items.push(parsed_comments);
+                }
             }
             if i > 0 {
                 items.push(Condition::new("afterSeparatorSpace", ConditionProperties {
                     condition: Box::new(move |condition_context| condition_resolvers::is_on_same_line(condition_context, &after_separator_info)),
-                    true_path: Some(vec![" ".into()]),
+                    true_path: Some(" ".into()),
                     false_path: None
                 }).into());
             }
-            items.extend(parse_node(type_node.into(), context));
-            items
+            items.push(parse_node(type_node.into(), context));
+            items.into()
         };
         // probably something better needs to be done here, but htis is good enough for now
         if is_ancestor_parenthesized_type || i == 0 && !is_parent_union_or_intersection_type {
-            items.extend(parsed_node);
+            items.push(parsed_node);
         } else {
             items.push(conditions::indent_if_start_of_line(parsed_node).into());
         }
     }
 
-    return items;
+    return items.into();
 
     fn get_separator_token<'a>(separator: &str, last_type_node: &dyn Ranged, parent: &dyn Ranged, context: &mut Context<'a>) -> Option<&'a TokenAndSpan> {
         let token = context.token_finder.get_first_operator_after(last_type_node, separator);
@@ -3488,17 +3540,19 @@ fn parse_union_or_intersection_type<'a>(node: UnionOrIntersectionType<'a>, conte
 
 /* comments */
 
-fn parse_leading_comments<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_leading_comments<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Option<PrintItem> {
     let leading_comments = node.leading_comments(context);
     parse_comments_as_leading(node, leading_comments, context)
 }
 
-fn parse_comments_as_leading<'a>(node: &dyn Spanned, comments: CommentsIterator<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_comments_as_leading<'a>(node: &dyn Spanned, comments: CommentsIterator<'a>, context: &mut Context<'a>) -> Option<PrintItem> {
     let mut items = Vec::new();
     if let Some(last_comment) = comments.get_last_comment() {
         let last_comment_previously_handled = context.has_handled_comment(&last_comment);
 
-        items.extend(parse_comment_collection(comments, None, context));
+        if let Some(parsed_comments) = parse_comment_collection(comments, None, context) {
+            items.push(parsed_comments);
+        }
 
         // todo: this doesn't seem exactly right...
         if !last_comment_previously_handled {
@@ -3517,10 +3571,10 @@ fn parse_comments_as_leading<'a>(node: &dyn Spanned, comments: CommentsIterator<
         }
     }
 
-    items
+    if items.is_empty() { None } else { Some(items.into()) }
 }
 
-fn parse_trailing_comments_as_statements<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_trailing_comments_as_statements<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Option<PrintItem> {
     let unhandled_comments = get_trailing_comments_as_statements(node, context);
     parse_comment_collection(unhandled_comments.into_iter(), Some(node), context)
 }
@@ -3533,22 +3587,22 @@ fn get_trailing_comments_as_statements<'a>(node: &dyn Spanned, context: &mut Con
             items.push(comment);
         }
     }
-    items
+    items.into()
 }
 
-fn parse_comment_collection<'a, CIter>(comments: CIter, last_node: Option<&dyn Spanned>, context: &mut Context<'a>) -> Vec<PrintItem> where CIter : Iterator<Item=&'a Comment> {
+fn parse_comment_collection<'a, CIter>(comments: CIter, last_node: Option<&dyn Spanned>, context: &mut Context<'a>) -> Option<PrintItem> where CIter : Iterator<Item=&'a Comment> {
     let mut last_node = last_node;
     let mut items = Vec::new();
     for comment in comments {
         if !context.has_handled_comment(comment) {
-            items.extend(parse_comment_based_on_last_node(comment, &last_node, context));
+            items.push(parse_comment_based_on_last_node(comment, &last_node, context));
             last_node = Some(comment);
         }
     }
-    items
+    if items.is_empty() { None } else { Some(items.into()) }
 }
 
-fn parse_comment_based_on_last_node(comment: &Comment, last_node: &Option<&dyn Spanned>, context: &mut Context) -> Vec<PrintItem> {
+fn parse_comment_based_on_last_node(comment: &Comment, last_node: &Option<&dyn Spanned>, context: &mut Context) -> PrintItem {
     let mut items = Vec::new();
 
     if let Some(last_node) = last_node {
@@ -3563,36 +3617,39 @@ fn parse_comment_based_on_last_node(comment: &Comment, last_node: &Option<&dyn S
         }
     }
 
-    items.extend(parse_comment(&comment, context));
-    return items;
+    if let Some(parsed_comment) = parse_comment(&comment, context) {
+        items.push(parsed_comment);
+    }
+
+    return items.into();
 }
 
-fn parse_comment(comment: &Comment, context: &mut Context) -> Vec<PrintItem> {
+fn parse_comment(comment: &Comment, context: &mut Context) -> Option<PrintItem> {
     // only parse if handled
     if context.has_handled_comment(comment) {
-        return Vec::new();
+        return None;
     }
 
     // mark handled and parse
     context.mark_comment_handled(comment);
-    return match comment.kind {
+    return Some(match comment.kind {
         CommentKind::Block => parse_comment_block(comment),
         CommentKind::Line => parse_comment_line(comment),
-    };
+    });
 
-    fn parse_comment_block(comment: &Comment) -> Vec<PrintItem> {
-        let mut vec = Vec::new();
-        vec.push("/*".into());
-        vec.extend(parse_raw_string(&comment.text));
-        vec.push("*/".into());
-        vec
+    fn parse_comment_block(comment: &Comment) -> PrintItem {
+        let mut items = Vec::new();
+        items.push("/*".into());
+        items.push(parse_raw_string(&comment.text));
+        items.push("*/".into());
+        items.into()
     }
 
-    fn parse_comment_line(comment: &Comment) -> Vec<PrintItem> {
+    fn parse_comment_line(comment: &Comment) -> PrintItem {
         return vec![
             get_comment_text(&comment.text).into(),
             PrintItem::ExpectNewLine
-        ];
+        ].into();
 
         fn get_comment_text(original_text: &String) -> String {
             let non_slash_index = get_first_non_slash_index(&original_text);
@@ -3622,24 +3679,22 @@ fn parse_comment(comment: &Comment, context: &mut Context) -> Vec<PrintItem> {
     }
 }
 
-fn parse_first_line_trailing_comments<'a>(node: &dyn Spanned, first_member: Option<&dyn Spanned>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_first_line_trailing_comments<'a>(node: &dyn Spanned, first_member: Option<&dyn Spanned>, context: &mut Context<'a>) -> Option<PrintItem> {
     let mut items = Vec::new();
     let node_start_line = node.start_line(context);
 
     for comment in get_comments(&node, &first_member, context) {
-        if context.has_handled_comment(&comment) {
-            continue;
-        }
-
         if comment.start_line(context) == node_start_line {
-            if comment.kind == CommentKind::Line {
-                items.push(" ".into());
+            if let Some(parsed_comment) = parse_comment(comment, context) {
+                if comment.kind == CommentKind::Line {
+                    items.push(" ".into());
+                }
+                items.push(parsed_comment);
             }
-            items.extend(parse_comment(&comment, context));
         }
     }
 
-    return items;
+    return if items.is_empty() { None } else { Some(items.into()) };
 
     fn get_comments<'a>(node: &dyn Spanned, first_member: &Option<&dyn Spanned>, context: &mut Context<'a>) -> Vec<&'a Comment> {
         let mut comments = Vec::new();
@@ -3652,13 +3707,13 @@ fn parse_first_line_trailing_comments<'a>(node: &dyn Spanned, first_member: Opti
     }
 }
 
-fn parse_trailing_comments<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_trailing_comments<'a>(node: &dyn Spanned, context: &mut Context<'a>) -> Option<PrintItem> {
     // todo: handle comments for object expr, arrayexpr, and tstupletype?
     let trailing_comments = node.trailing_comments(context);
     parse_comments_as_trailing(node, trailing_comments, context)
 }
 
-fn parse_comments_as_trailing<'a>(node: &dyn Spanned, trailing_comments: CommentsIterator<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_comments_as_trailing<'a>(node: &dyn Spanned, trailing_comments: CommentsIterator<'a>, context: &mut Context<'a>) -> Option<PrintItem> {
     // use the roslyn definition of trailing comments
     let node_end_line = node.end_line(context);
     let trailing_comments_on_same_line = trailing_comments.into_iter().filter(|c| c.start_line(context) == node_end_line).collect::<Vec<&'a Comment>>();
@@ -3671,9 +3726,11 @@ fn parse_comments_as_trailing<'a>(node: &dyn Spanned, trailing_comments: Comment
         }
     }
 
-    items.extend(parse_comment_collection(trailing_comments_on_same_line.into_iter(), Some(node), context));
+    if let Some(parsed_comments) = parse_comment_collection(trailing_comments_on_same_line.into_iter(), Some(node), context) {
+        items.push(parsed_comments);
+    }
 
-    return items;
+    return if items.is_empty() { None } else { Some(items.into()) };
 }
 
 fn get_jsx_empty_expr_comments<'a>(node: &JSXEmptyExpr, context: &mut Context<'a>) -> CommentsIterator<'a> {
@@ -3688,7 +3745,7 @@ struct ParseArrayLikeNodesOptions<'a> {
     trailing_commas: TrailingCommas,
 }
 
-fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mut Context<'a>) -> PrintItem {
     let parent_span = opts.parent_span;
     let elements = opts.elements;
     let use_new_lines = get_use_new_lines(&parent_span, &elements, context);
@@ -3697,13 +3754,13 @@ fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mu
 
     items.push("[".into());
     if !elements.is_empty() {
-        items.extend(parse_elements(&parent_span, elements, use_new_lines, force_trailing_commas, context));
+        items.push(parse_elements(&parent_span, elements, use_new_lines, force_trailing_commas, context));
     }
     items.push("]".into());
 
-    return items;
+    return items.into();
 
-    fn parse_elements<'a>(parent_span: &Span, elements: Vec<Option<Node<'a>>>, use_new_lines: bool, force_trailing_commas: bool, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_elements<'a>(parent_span: &Span, elements: Vec<Option<Node<'a>>>, use_new_lines: bool, force_trailing_commas: bool, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
         let elements_len = elements.len();
 
@@ -3720,17 +3777,16 @@ fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mu
             if use_new_lines { items.push(PrintItem::NewLine); }
         }
 
-        return items;
+        return items.into();
     }
 
-    fn parse_element<'a>(parent_span: &Span, element: Option<Node<'a>>, has_comma: bool, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_element<'a>(parent_span: &Span, element: Option<Node<'a>>, has_comma: bool, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
         let comma_token = get_comma_token(parent_span, &element, context);
 
         if let Some(element) = element {
-            items.extend(parse_node_with_inner_parse(element, context, move |mut items| {
-                if has_comma { items.push(",".into()); }
-                items
+            items.push(parse_node_with_inner_parse(element, context, move |item| {
+                if has_comma { vec![item, ",".into()].into() } else { item }
             }));
         } else if has_comma {
             items.push(",".into());
@@ -3738,9 +3794,11 @@ fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mu
 
         // get the trailing comments after the comma token
         if let Some(comma_token) = &comma_token {
-            items.extend(parse_trailing_comments(comma_token, context));
+            if let Some(parsed_comments) = parse_trailing_comments(comma_token, context) {
+                items.push(parsed_comments);
+            }
         }
-        return items;
+        return items.into();
 
         fn get_comma_token<'a>(parent_span: &Span, element: &Option<Node<'a>>, context: &mut Context<'a>) -> Option<&'a TokenAndSpan> {
             if let Some(element) = &element {
@@ -3790,28 +3848,30 @@ struct ParseMemberedBodyOptions<'a, FShouldUseBlankLine> where FShouldUseBlankLi
 fn parse_membered_body<'a, FShouldUseBlankLine>(
     opts: ParseMemberedBodyOptions<'a, FShouldUseBlankLine>,
     context: &mut Context<'a>
-) -> Vec<PrintItem>
+) -> PrintItem
     where FShouldUseBlankLine : Fn(&Node, &Node, &mut Context) -> bool
 {
     let mut items = Vec::new();
     let open_brace_token = context.token_finder.get_first_open_brace_token_before(&if opts.members.is_empty() { opts.span.hi() } else { opts.members[0].lo() });
     let close_brace_token_pos = BytePos(opts.span.hi().0 - 1);
 
-    items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+    items.push(parse_brace_separator(ParseBraceSeparatorOptions {
         brace_position: opts.brace_position,
         open_brace_token: open_brace_token,
         start_header_info: opts.start_header_info,
     }, context));
 
     items.push("{".into());
-    items.extend(parse_trailing_comments(&open_brace_token, context));
-    items.extend(parser_helpers::with_indent({
+    if let Some(parsed_comments) = parse_trailing_comments(&open_brace_token, context) {
+        items.push(parsed_comments);
+    }
+    items.push(parser_helpers::with_indent({
         let mut items = Vec::new();
         if !opts.members.is_empty() || close_brace_token_pos.leading_comments(context).any(|c| !context.has_handled_comment(&c)) {
             items.push(PrintItem::NewLine);
         }
 
-        items.extend(parse_statements_or_members(ParseStatementsOrMembersOptions {
+        items.push(parse_statements_or_members(ParseStatementsOrMembersOptions {
             inner_span: Span::new(open_brace_token.hi(), close_brace_token_pos.lo(), Default::default()),
             items: opts.members.into_iter().map(|node| (node, None)).collect(),
             should_use_space: None,
@@ -3820,15 +3880,15 @@ fn parse_membered_body<'a, FShouldUseBlankLine>(
             trailing_commas: opts.trailing_commas,
         }, context));
 
-        items
+        items.into()
     }));
     items.push(PrintItem::NewLine);
     items.push("}".into());
 
-    items
+    items.into()
 }
 
-fn parse_statements<'a>(inner_span: Span, stmts: Vec<Node<'a>>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_statements<'a>(inner_span: Span, stmts: Vec<Node<'a>>, context: &mut Context<'a>) -> PrintItem {
     parse_statements_or_members(ParseStatementsOrMembersOptions {
         inner_span,
         items: stmts.into_iter().map(|stmt| (stmt, None)).collect(),
@@ -3841,7 +3901,7 @@ fn parse_statements<'a>(inner_span: Span, stmts: Vec<Node<'a>>, context: &mut Co
 
 struct ParseStatementsOrMembersOptions<'a, FShouldUseBlankLine> where FShouldUseBlankLine : Fn(&Node, &Node, &mut Context) -> bool {
     inner_span: Span,
-    items: Vec<(Node<'a>, Option<Vec<PrintItem>>)>,
+    items: Vec<(Node<'a>, Option<PrintItem>)>,
     should_use_space: Option<Box<dyn Fn(&Node, &Node, &mut Context) -> bool>>,
     should_use_new_line: Option<Box<dyn Fn(&Node, &Node, &mut Context) -> bool>>,
     should_use_blank_line: FShouldUseBlankLine,
@@ -3851,7 +3911,7 @@ struct ParseStatementsOrMembersOptions<'a, FShouldUseBlankLine> where FShouldUse
 fn parse_statements_or_members<'a, FShouldUseBlankLine>(
     opts: ParseStatementsOrMembersOptions<'a, FShouldUseBlankLine>,
     context: &mut Context<'a>
-) -> Vec<PrintItem> where FShouldUseBlankLine : Fn(&Node, &Node, &mut Context) -> bool
+) -> PrintItem where FShouldUseBlankLine : Fn(&Node, &Node, &mut Context) -> bool
 {
     let mut last_node: Option<Node> = None;
     let mut items = Vec::new();
@@ -3875,18 +3935,21 @@ fn parse_statements_or_members<'a, FShouldUseBlankLine>(
 
         let end_info = Info::new("endStatementOrMemberInfo");
         context.end_statement_or_member_infos.push(end_info.clone());
-        items.extend(if let Some(print_items) = optional_print_items {
+        items.push(if let Some(print_items) = optional_print_items {
             print_items
         } else {
             let trailing_commas = opts.trailing_commas;
-            parse_node_with_inner_parse(node.clone(), context, move |mut items| {
+            parse_node_with_inner_parse(node.clone(), context, move |item| {
                 if let Some(trailing_commas) = trailing_commas {
                     let force_trailing_commas = get_force_trailing_commas(trailing_commas, true);
                     if force_trailing_commas || i < children_len - 1 {
-                        items.push(",".into())
+                        vec![item, ",".into()].into()
+                    } else {
+                        item
                     }
+                } else {
+                    item
                 }
-                items
             })
         });
         items.push(end_info.into());
@@ -3896,14 +3959,18 @@ fn parse_statements_or_members<'a, FShouldUseBlankLine>(
     }
 
     if let Some(last_node) = &last_node {
-        items.extend(parse_trailing_comments_as_statements(last_node, context));
+        if let Some(parsed_comments) = parse_trailing_comments_as_statements(last_node, context) {
+            items.push(parsed_comments);
+        }
     }
 
     if children_len == 0 {
-        items.extend(parse_comment_collection(opts.inner_span.hi().leading_comments(context), None, context));
+        if let Some(parsed_comments) = parse_comment_collection(opts.inner_span.hi().leading_comments(context), None, context) {
+            items.push(parsed_comments);
+        }
     }
 
-    return items;
+    return items.into();
 
     fn should_use_new_line(
         should_use_new_line: &Option<Box<dyn Fn(&Node, &Node, &mut Context) -> bool>>,
@@ -3921,10 +3988,10 @@ fn parse_statements_or_members<'a, FShouldUseBlankLine>(
 struct ParseParametersOrArgumentsOptions<'a> {
     nodes: Vec<Node<'a>>,
     force_multi_line_when_multiple_lines: bool,
-    custom_close_paren: Option<Vec<PrintItem>>,
+    custom_close_paren: Option<PrintItem>,
 }
 
-fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>, context: &mut Context<'a>) -> PrintItem {
     let nodes = opts.nodes;
     let start_info = Info::new("startParamsOrArgs");
     let end_info = Info::new("endParamsOrArgs");
@@ -3943,7 +4010,7 @@ fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>
         }
     };
 
-    let mut items: Vec<PrintItem> = Vec::new();
+    let mut items = Vec::new();
     items.push(start_info.into());
     items.push("(".into());
 
@@ -3955,7 +4022,7 @@ fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>
     }).into());
 
     if let Some(custom_close_paren) = opts.custom_close_paren {
-        items.extend(custom_close_paren);
+        items.push(custom_close_paren);
     }
     else {
         items.push(")".into());
@@ -3963,7 +4030,7 @@ fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>
 
     items.push(end_info.into());
 
-    return items;
+    return items.into();
 
     fn get_use_new_lines(nodes: &Vec<Node>, context: &mut Context) -> bool {
         if nodes.is_empty() {
@@ -3985,10 +4052,10 @@ fn parse_parameters_or_arguments<'a>(opts: ParseParametersOrArgumentsOptions<'a>
 struct ParseCloseParenWithTypeOptions<'a> {
     start_info: Info,
     type_node: Option<Node<'a>>,
-    type_node_separator: Option<Vec<PrintItem>>,
+    type_node_separator: Option<PrintItem>,
 }
 
-fn parse_close_paren_with_type<'a>(opts: ParseCloseParenWithTypeOptions<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_close_paren_with_type<'a>(opts: ParseCloseParenWithTypeOptions<'a>, context: &mut Context<'a>) -> PrintItem {
     // todo: clean this up a bit
     let type_node_start_info = Info::new("typeNodeStart");
     let has_type_node = opts.type_node.is_some();
@@ -4008,33 +4075,33 @@ fn parse_close_paren_with_type<'a>(opts: ParseCloseParenWithTypeOptions<'a>, con
             }
             return None;
         }),
-        true_path: Some(vec![PrintItem::NewLine]),
+        true_path: Some(PrintItem::NewLine),
         false_path: None,
     }).into());
     items.push(")".into());
-    items.extend(parsed_type_node);
-    return items;
+    items.push(parsed_type_node);
+    return items.into();
 
     fn parse_type_node<'a>(
         type_node: Option<Node<'a>>,
-        type_node_separator: Option<Vec<PrintItem>>,
+        type_node_separator: Option<PrintItem>,
         type_node_start_info: Info,
         type_node_end_info: Info,
         context: &mut Context<'a>
-    ) -> Vec<PrintItem> {
+    ) -> PrintItem {
         let mut items = Vec::new();
         if let Some(type_node) = type_node {
             items.push(type_node_start_info.into());
             if let Some(type_node_separator) = type_node_separator {
-                items.extend(type_node_separator);
+                items.push(type_node_separator);
             } else {
                 if context.config.type_annotation_space_before_colon { items.push(" ".into()); }
                 items.push(": ".into());
             }
-            items.extend(parse_node(type_node.into(), context));
+            items.push(parse_node(type_node.into(), context));
             items.push(type_node_end_info.into());
         }
-        return items;
+        return items.into();
     }
 }
 
@@ -4042,7 +4109,7 @@ fn parse_comma_separated_values<'a>(
     values: Vec<Node<'a>>,
     multi_line_or_hanging_condition_resolver: impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static,
     context: &mut Context<'a>
-) -> Vec<PrintItem> {
+) -> PrintItem {
     let mut items = Vec::new();
     let values_count = values.len();
 
@@ -4051,69 +4118,70 @@ fn parse_comma_separated_values<'a>(
         let parsed_value = parse_value(value, has_comma, context);
 
         if i == 0 {
-            items.extend(parsed_value);
+            items.push(parsed_value);
         } else {
             items.push(Condition::new("multiLineOrHangingCondition", ConditionProperties {
                 condition: Box::new(multi_line_or_hanging_condition_resolver.clone()),
                 true_path: {
                     let mut items = Vec::new();
                     items.push(PrintItem::NewLine);
-                    items.extend(parsed_value.clone());
-                    Some(items)
+                    items.push(parsed_value.clone());
+                    Some(items.into())
                 },
                 false_path: {
                     let mut items = Vec::new();
                     items.push(PrintItem::SpaceOrNewLine);
                     items.push(conditions::indent_if_start_of_line(parsed_value).into());
-                    Some(items)
+                    Some(items.into())
                 },
             }).into());
         }
     }
 
-    return items;
+    return items.into();
 
-    fn parse_value<'a>(value: Node<'a>, has_comma: bool, context: &mut Context<'a>) -> Vec<PrintItem> {
-        parser_helpers::new_line_group(parse_node_with_inner_parse(value, context, move |mut items| {
+    fn parse_value<'a>(value: Node<'a>, has_comma: bool, context: &mut Context<'a>) -> PrintItem {
+        parser_helpers::new_line_group(parse_node_with_inner_parse(value, context, move |item| {
             if has_comma {
-                items.push(",".into());
+                vec![item, ",".into()].into()
+            } else {
+                item
             }
-            items
-        }))
+        })).into()
     }
 }
 
 /// For some reason, some nodes don't have a TsTypeAnn, but instead of a Box<TsType>
-fn parse_type_annotation_with_colon_if_exists_for_type<'a>(type_ann: &'a Option<Box<TsType>>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_annotation_with_colon_if_exists_for_type<'a>(type_ann: &'a Option<Box<TsType>>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if let Some(type_ann) = type_ann {
         if context.config.type_annotation_space_before_colon {
             items.push(" ".into());
         }
-        items.extend(parse_node_with_preceeding_colon(Some(type_ann.into()), context));
+        items.push(parse_node_with_preceeding_colon(Some(type_ann.into()), context));
     }
-    items
+    items.into()
 }
 
-fn parse_type_annotation_with_colon_if_exists<'a>(type_ann: &'a Option<TsTypeAnn>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_type_annotation_with_colon_if_exists<'a>(type_ann: &'a Option<TsTypeAnn>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if let Some(type_ann) = type_ann {
         if context.config.type_annotation_space_before_colon {
             items.push(" ".into());
         }
-        items.extend(parse_node_with_preceeding_colon(Some(type_ann.into()), context));
+        items.push(parse_node_with_preceeding_colon(Some(type_ann.into()), context));
     }
-    items
+    items.into()
 }
 
-fn parse_node_with_preceeding_colon<'a>(node: Option<Node<'a>>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_node_with_preceeding_colon<'a>(node: Option<Node<'a>>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if let Some(node) = node {
         items.push(":".into());
         items.push(PrintItem::SpaceOrNewLine);
         items.push(conditions::indent_if_start_of_line(parse_node(node, context)).into());
     }
-    items
+    items.into()
 }
 
 struct ParseBraceSeparatorOptions<'a> {
@@ -4122,27 +4190,27 @@ struct ParseBraceSeparatorOptions<'a> {
     start_header_info: Option<Info>,
 }
 
-fn parse_brace_separator<'a>(opts: ParseBraceSeparatorOptions<'a>, context: &mut Context) -> Vec<PrintItem> {
+fn parse_brace_separator<'a>(opts: ParseBraceSeparatorOptions<'a>, context: &mut Context) -> PrintItem {
     match opts.brace_position {
         BracePosition::NextLineIfHanging => {
             if let Some(start_header_info) = opts.start_header_info {
-                vec![conditions::new_line_if_hanging_space_otherwise(conditions::NewLineIfHangingSpaceOtherwiseOptions {
+                conditions::new_line_if_hanging_space_otherwise(conditions::NewLineIfHangingSpaceOtherwiseOptions {
                     start_info: start_header_info,
                     end_info: None,
                     space_char: None,
-                }).into()]
+                }).into()
             } else {
-                vec![" ".into()]
+                " ".into()
             }
         },
         BracePosition::SameLine => {
-            vec![" ".into()]
+            " ".into()
         },
         BracePosition::NextLine => {
-            vec![PrintItem::NewLine]
+            PrintItem::NewLine
         },
         BracePosition::Maintain => {
-            vec![if let Some(open_brace_token) = opts.open_brace_token {
+            if let Some(open_brace_token) = opts.open_brace_token {
                 if node_helpers::is_first_node_on_line(open_brace_token, context) {
                     PrintItem::NewLine
                 } else {
@@ -4150,12 +4218,12 @@ fn parse_brace_separator<'a>(opts: ParseBraceSeparatorOptions<'a>, context: &mut
                 }
             } else {
                 " ".into()
-            }]
+            }
         },
     }
 }
 
-fn parse_node_in_parens<'a, F>(first_inner_node: Node<'a>, inner_parse_node: F, context: &mut Context<'a>) -> Vec<PrintItem> where F : Fn(&mut Context<'a>) -> Vec<PrintItem> {
+fn parse_node_in_parens<'a, F>(first_inner_node: Node<'a>, inner_parse_node: F, context: &mut Context<'a>) -> PrintItem where F : Fn(&mut Context<'a>) -> PrintItem {
     let open_paren_token = context.token_finder.get_previous_token_if_open_paren(&first_inner_node);
     let use_new_lines = {
         if let Some(open_paren_token) = &open_paren_token {
@@ -4174,27 +4242,27 @@ fn parse_node_in_parens<'a, F>(first_inner_node: Node<'a>, inner_parse_node: F, 
     return wrap_in_parens(inner_parse_node(context), use_new_lines);
 }
 
-fn wrap_in_parens(parsed_node: Vec<PrintItem>, use_new_lines: bool) -> Vec<PrintItem> {
+fn wrap_in_parens(parsed_node: PrintItem, use_new_lines: bool) -> PrintItem {
     parser_helpers::new_line_group({
         let mut items = Vec::new();
         items.push("(".into());
         if use_new_lines {
             items.push(PrintItem::NewLine);
-            items.extend(parser_helpers::with_indent(parsed_node));
+            items.push(parser_helpers::with_indent(parsed_node));
             items.push(PrintItem::NewLine);
         } else {
-            items.extend(parsed_node);
+            items.push(parsed_node);
         }
         items.push(")".into());
-        items
+        items.into()
     })
 }
 
-fn parse_extends_or_implements<'a>(text: &'a str, type_items: Vec<Node<'a>>, start_header_info: Info, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_extends_or_implements<'a>(text: &'a str, type_items: Vec<Node<'a>>, start_header_info: Info, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     if type_items.is_empty() {
-        return items;
+        return items.into();
     }
 
     items.push(conditions::new_line_if_multiple_lines_space_or_new_line_otherwise(start_header_info, None).into());
@@ -4210,10 +4278,10 @@ fn parse_extends_or_implements<'a>(text: &'a str, type_items: Vec<Node<'a>>, sta
 
             items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node(type_item, context))).into());
         }
-        items
+        items.into()
     })).into());
 
-    return items;
+    return items.into();
 }
 
 struct ParseObjectLikeNodeOptions<'a> {
@@ -4222,12 +4290,12 @@ struct ParseObjectLikeNodeOptions<'a> {
     trailing_commas: Option<TrailingCommas>,
 }
 
-fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
 
     if opts.members.is_empty() {
         items.push("{}".into()); // todo: comments?
-        return items;
+        return items.into();
     }
 
     let open_brace_token = context.token_finder.get_first_open_brace_token_within(&opts.node_span).expect("Expected to find an open brace token.");
@@ -4243,7 +4311,7 @@ fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mu
     items.push(separator.clone());
 
     if multi_line {
-        items.extend(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
+        items.push(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
             inner_span: Span::new(open_brace_token.hi(), close_brace_token.lo(), Default::default()),
             items: opts.members.into_iter().map(|member| (member.into(), None)).collect(),
             should_use_space: None,
@@ -4257,13 +4325,16 @@ fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mu
             if i > 0 { items.push(PrintItem::SpaceOrNewLine); }
 
             let trailing_commas = opts.trailing_commas;
-            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node_with_inner_parse(member, context, move |mut items| {
+            items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parse_node_with_inner_parse(member, context, move |item| {
                 if let Some(trailing_commas) = trailing_commas {
                     if i < members_len - 1 || get_force_trailing_commas(trailing_commas, multi_line) {
-                        items.push(",".into());
+                        vec![item, ",".into()].into()
+                    } else {
+                        item
                     }
+                } else {
+                    item
                 }
-                items
             }))).into());
         }
     }
@@ -4271,7 +4342,7 @@ fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mu
     items.push(separator);
     items.push("}".into());
 
-    return items;
+    return items.into();
 }
 
 struct MemberLikeExpr<'a> {
@@ -4280,12 +4351,12 @@ struct MemberLikeExpr<'a> {
     is_computed: bool,
 }
 
-fn parse_for_member_like_expr<'a>(node: MemberLikeExpr<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_for_member_like_expr<'a>(node: MemberLikeExpr<'a>, context: &mut Context<'a>) -> PrintItem {
     let use_new_line = node_helpers::get_use_new_lines_for_nodes(&node.left_node, &node.right_node, context);
     let mut items = Vec::new();
     let is_optional = context.parent().kind() == NodeKind::OptChainExpr;
 
-    items.extend(parse_node(node.left_node, context));
+    items.push(parse_node(node.left_node, context));
     items.push(if use_new_line { PrintItem::NewLine } else { PrintItem::PossibleNewLine });
     items.push(conditions::indent_if_start_of_line({
         let mut items = Vec::new();
@@ -4295,19 +4366,19 @@ fn parse_for_member_like_expr<'a>(node: MemberLikeExpr<'a>, context: &mut Contex
             if node.is_computed { items.push(".".into()); }
         }
         items.push(if node.is_computed { "[" } else { "." }.into());
-        items.extend(parse_node(node.right_node, context));
+        items.push(parse_node(node.right_node, context));
         if node.is_computed { items.push("]".into()); }
 
-        items
+        items.into()
     }).into());
 
-    return items;
+    return items.into();
 }
 
-fn parse_decorators<'a>(decorators: &'a Vec<Decorator>, is_inline: bool, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_decorators<'a>(decorators: &'a Vec<Decorator>, is_inline: bool, context: &mut Context<'a>) -> PrintItem {
     let mut items = Vec::new();
     if decorators.is_empty() {
-        return items;
+        return items.into();
     }
 
     let use_new_lines = !is_inline
@@ -4327,7 +4398,7 @@ fn parse_decorators<'a>(decorators: &'a Vec<Decorator>, is_inline: bool, context
         if is_inline {
             items.push(conditions::indent_if_start_of_line(parser_helpers::new_line_group(parsed_node)).into());
         } else {
-            items.extend(parser_helpers::new_line_group(parsed_node));
+            items.push(parser_helpers::new_line_group(parsed_node));
         }
     }
 
@@ -4337,7 +4408,7 @@ fn parse_decorators<'a>(decorators: &'a Vec<Decorator>, is_inline: bool, context
         PrintItem::NewLine
     });
 
-    return items;
+    return items.into();
 }
 
 fn parse_control_flow_separator(
@@ -4345,7 +4416,7 @@ fn parse_control_flow_separator(
     previous_node_block: &Span,
     token_text: &str,
     context: &mut Context
-) -> Vec<PrintItem> {
+) -> PrintItem {
     let mut items = Vec::new();
     match next_control_flow_position {
         NextControlFlowPosition::SameLine => items.push(" ".into()),
@@ -4360,13 +4431,13 @@ fn parse_control_flow_separator(
             }
         }
     }
-    return items;
+    return items.into();
 }
 
 struct ParseHeaderWithConditionalBraceBodyOptions<'a> {
     parent: &'a Span,
     body_node: Node<'a>,
-    parsed_header: Vec<PrintItem>,
+    parsed_header: PrintItem,
     use_braces: UseBraces,
     brace_position: BracePosition,
     single_body_position: Option<SingleBodyPosition>,
@@ -4374,7 +4445,7 @@ struct ParseHeaderWithConditionalBraceBodyOptions<'a> {
 }
 
 struct ParseHeaderWithConditionalBraceBodyResult {
-    parsed_node: Vec<PrintItem>,
+    parsed_node: PrintItem,
     open_brace_condition: Condition,
 }
 
@@ -4384,7 +4455,7 @@ fn parse_header_with_conditional_brace_body<'a>(opts: ParseHeaderWithConditional
     let mut items = Vec::new();
 
     items.push(start_header_info.clone().into());
-    items.extend(opts.parsed_header);
+    items.push(opts.parsed_header);
     items.push(end_header_info.clone().into());
     let result = parse_conditional_brace_body(ParseConditionalBraceBodyOptions {
         parent: opts.parent,
@@ -4397,11 +4468,11 @@ fn parse_header_with_conditional_brace_body<'a>(opts: ParseHeaderWithConditional
         start_header_info: Some(start_header_info),
         end_header_info: Some(end_header_info),
     }, context);
-    items.extend(result.parsed_node);
+    items.push(result.parsed_node);
 
     return ParseHeaderWithConditionalBraceBodyResult {
         open_brace_condition: result.open_brace_condition,
-        parsed_node: items,
+        parsed_node: items.into(),
     };
 }
 
@@ -4418,7 +4489,7 @@ struct ParseConditionalBraceBodyOptions<'a> {
 }
 
 struct ParseConditionalBraceBodyResult {
-    parsed_node: Vec<PrintItem>,
+    parsed_node: PrintItem,
     open_brace_condition: Condition,
 }
 
@@ -4457,8 +4528,8 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
                 return Some(resolved_end_statements_info.line_number > resolved_start_info.line_number);
             })
         },
-        true_path: Some(vec![PrintItem::NewLine]),
-        false_path: Some(vec![" ".into()]),
+        true_path: Some(PrintItem::NewLine),
+        false_path: Some(" ".into()),
     });
     let open_brace_condition = Condition::new("openBrace", ConditionProperties {
         condition: {
@@ -4505,13 +4576,13 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
         },
         true_path: {
             let mut items = Vec::new();
-            items.extend(parse_brace_separator(ParseBraceSeparatorOptions {
+            items.push(parse_brace_separator(ParseBraceSeparatorOptions {
                 brace_position: opts.brace_position,
                 open_brace_token: open_brace_token,
                 start_header_info: start_header_info.clone(),
             }, context));
             items.push("{".into());
-            Some(items)
+            Some(items.into())
         },
         false_path: None,
     });
@@ -4519,26 +4590,33 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
     // parse body
     let mut items = Vec::new();
     items.push(open_brace_condition.clone().into());
-    items.extend(parser_helpers::prepend_if_has_items(parse_comment_collection(header_trailing_comments.into_iter(), None, context), " ".into()));
+    if let Some(parsed_comments) = parse_comment_collection(header_trailing_comments.into_iter(), None, context) {
+        items.push(" ".into());
+        items.push(parsed_comments);
+    }
     items.push(newline_or_space_condition.clone().into());
     items.push(start_statements_info.clone().into());
 
     if let Node::BlockStmt(body_node) = opts.body_node {
-        items.extend(parser_helpers::with_indent({
+        items.push(parser_helpers::with_indent({
             let mut items = Vec::new();
             // parse the remaining trailing comments inside because some of them are parsed already
             // by parsing the header trailing comments
-            items.extend(parse_leading_comments(&body_node, context));
-            items.extend(parse_statements(body_node.get_inner_span(context), body_node.stmts.iter().map(|x| x.into()).collect(), context));
-            items
+            if let Some(parsed_comments) = parse_leading_comments(&body_node, context) {
+                items.push(parsed_comments);
+            }
+            items.push(parse_statements(body_node.get_inner_span(context), body_node.stmts.iter().map(|x| x.into()).collect(), context));
+            items.into()
         }));
     } else {
-        items.extend(parser_helpers::with_indent({
+        items.push(parser_helpers::with_indent({
             let mut items = Vec::new();
             let body_node_span = opts.body_node.span();
-            items.extend(parse_node(opts.body_node, context));
-            items.extend(parse_trailing_comments(&body_node_span, context));
-            items
+            items.push(parse_node(opts.body_node, context));
+            if let Some(parsed_comments) = parse_trailing_comments(&body_node_span, context) {
+                items.push(parsed_comments);
+            }
+            items.into()
         }));
     }
 
@@ -4559,24 +4637,24 @@ fn parse_conditional_brace_body<'a>(opts: ParseConditionalBraceBodyOptions<'a>, 
                         return Some(!are_infos_equal);
                     })
                 },
-                true_path: Some(vec![PrintItem::NewLine]),
-                false_path: Some(vec![Condition::new("closeBraceSpace", ConditionProperties {
+                true_path: Some(PrintItem::NewLine),
+                false_path: Some(Condition::new("closeBraceSpace", ConditionProperties {
                     condition: Box::new(move |condition_context| {
                         let is_new_line = condition_context.get_resolved_condition(&newline_or_space_condition)?;
                         return Some(!is_new_line);
                     }),
-                    true_path: Some(vec![" ".into()]),
+                    true_path: Some(" ".into()),
                     false_path: None,
-                }).into()])
+                }).into())
             }).into(),
             "}".into()
-        ]),
+        ].into()),
         false_path: None,
     }).into());
 
     // return result
     return ParseConditionalBraceBodyResult {
-        parsed_node: items,
+        parsed_node: items.into(),
         open_brace_condition,
     };
 
@@ -4681,7 +4759,7 @@ struct ParseJsxWithOpeningAndClosingOptions<'a> {
     children: Vec<Node<'a>>,
 }
 
-fn parse_jsx_with_opening_and_closing<'a>(opts: ParseJsxWithOpeningAndClosingOptions<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_with_opening_and_closing<'a>(opts: ParseJsxWithOpeningAndClosingOptions<'a>, context: &mut Context<'a>) -> PrintItem {
     let use_multi_lines = get_use_multi_lines(&opts.opening_element, &opts.children, context);
     let children = opts.children.into_iter().filter(|c| match c {
         Node::JSXText(c) => !c.text(context).trim().is_empty(),
@@ -4693,18 +4771,18 @@ fn parse_jsx_with_opening_and_closing<'a>(opts: ParseJsxWithOpeningAndClosingOpt
     let inner_span = Span::new(opts.opening_element.span().hi(), opts.closing_element.span().lo(), Default::default());
 
     items.push(start_info.clone().into());
-    items.extend(parse_node(opts.opening_element, context));
-    items.extend(parse_jsx_children(ParseJsxChildrenOptions {
+    items.push(parse_node(opts.opening_element, context));
+    items.push(parse_jsx_children(ParseJsxChildrenOptions {
         inner_span,
         children,
         parent_start_info: start_info,
         parent_end_info: end_info.clone(),
         use_multi_lines,
     }, context));
-    items.extend(parse_node(opts.closing_element, context));
+    items.push(parse_node(opts.closing_element, context));
     items.push(end_info.into());
 
-    return items;
+    return items.into();
 
     fn get_use_multi_lines(opening_element: &Node, children: &Vec<Node>, context: &mut Context) -> bool {
         if let Some(first_child) = children.get(0) {
@@ -4729,7 +4807,7 @@ struct ParseJsxChildrenOptions<'a> {
     use_multi_lines: bool,
 }
 
-fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Context<'a>) -> Vec<PrintItem> {
+fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Context<'a>) -> PrintItem {
     // Need to parse the children here so they only get parsed once.
     // Nodes need to be only parsed once so that their comments don't end up in
     // the handled comments collection and the second time they won't be parsed out.
@@ -4742,7 +4820,7 @@ fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Conte
     }
     else {
         // decide whether newlines should be used or not
-        return vec![Condition::new("jsxChildrenNewLinesOrNot", ConditionProperties {
+        return Condition::new("jsxChildrenNewLinesOrNot", ConditionProperties {
             condition: Box::new(move |condition_context| {
                 // use newlines if the header is multiple lines
                 let resolved_parent_start_info = condition_context.get_resolved_info(&parent_start_info)?;
@@ -4755,14 +4833,14 @@ fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Conte
             }),
             true_path: Some(parse_for_new_lines(children.clone(), opts.inner_span, context)),
             false_path: Some(parse_for_single_line(children, context)),
-        }).into()];
+        }).into();
     }
 
-    fn parse_for_new_lines<'a>(children: Vec<(Node<'a>, Vec<PrintItem>)>, inner_span: Span, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_for_new_lines<'a>(children: Vec<(Node<'a>, PrintItem)>, inner_span: Span, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
         let has_children = !children.is_empty();
         items.push(PrintItem::NewLine);
-        items.extend(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
+        items.push(parser_helpers::with_indent(parse_statements_or_members(ParseStatementsOrMembersOptions {
             inner_span,
             items: children.into_iter().map(|(a, b)| (a, Some(b))).collect(),
             should_use_space: Some(Box::new(|previous, next, context| should_use_space(previous, next, context))),
@@ -4791,10 +4869,10 @@ fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Conte
             items.push(PrintItem::NewLine);
         }
 
-        return items;
+        return items.into();
     }
 
-    fn parse_for_single_line<'a>(children: Vec<(Node<'a>, Vec<PrintItem>)>, context: &mut Context<'a>) -> Vec<PrintItem> {
+    fn parse_for_single_line<'a>(children: Vec<(Node<'a>, PrintItem)>, context: &mut Context<'a>) -> PrintItem {
         let mut items = Vec::new();
         if children.is_empty() {
             items.push(PrintItem::PossibleNewLine);
@@ -4807,12 +4885,12 @@ fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Conte
                     }
                 }
 
-                items.extend(parsed_child);
+                items.push(parsed_child);
                 items.push(PrintItem::PossibleNewLine);
                 previous_child = Some(child);
             }
         }
-        return items;
+        return items.into();
     }
 
     fn should_use_space(previous_element: &Node, next_element: &Node, context: &mut Context) -> bool {

--- a/packages/rust-dprint-plugin-typescript/src/parser_types.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser_types.rs
@@ -2,7 +2,7 @@ use std::str;
 use std::rc::Rc;
 use super::*;
 use std::collections::{HashSet, HashMap};
-use dprint_core::{Info, Condition};
+use dprint_core::{Info, ConditionReference};
 use utils::{Stack};
 use swc_common::{SpanData, BytePos, comments::{Comment}, SourceFile, Spanned, Span};
 use swc_ecma_ast::*;
@@ -20,7 +20,7 @@ pub struct Context<'a> {
     stored_infos: HashMap<BytePos, Info>,
     pub end_statement_or_member_infos: Stack<Info>,
     disable_indent_for_next_bin_expr: bool,
-    if_stmt_last_brace_condition: Option<Condition>,
+    if_stmt_last_brace_condition_ref: Option<ConditionReference>,
 }
 
 impl<'a> Context<'a> {
@@ -45,7 +45,7 @@ impl<'a> Context<'a> {
             stored_infos: HashMap::new(),
             end_statement_or_member_infos: Stack::new(),
             disable_indent_for_next_bin_expr: false,
-            if_stmt_last_brace_condition: None,
+            if_stmt_last_brace_condition_ref: None,
         }
     }
 
@@ -84,12 +84,12 @@ impl<'a> Context<'a> {
         return value;
     }
 
-    pub fn store_if_stmt_last_brace_condition(&mut self, condition: Condition) {
-        self.if_stmt_last_brace_condition = Some(condition);
+    pub fn store_if_stmt_last_brace_condition_ref(&mut self, condition_reference: ConditionReference) {
+        self.if_stmt_last_brace_condition_ref = Some(condition_reference);
     }
 
-    pub fn take_if_stmt_last_brace_condition(&mut self) -> Option<Condition> {
-        self.if_stmt_last_brace_condition.take()
+    pub fn take_if_stmt_last_brace_condition_ref(&mut self) -> Option<ConditionReference> {
+        self.if_stmt_last_brace_condition_ref.take()
     }
 }
 

--- a/packages/rust-dprint-plugin-typescript/src/parser_types.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser_types.rs
@@ -70,8 +70,8 @@ impl<'a> Context<'a> {
         self.stored_infos.insert(node.lo(), info);
     }
 
-    pub fn get_info_for_node(&self, node: &dyn Ranged) -> Option<&Info> {
-        self.stored_infos.get(&node.lo())
+    pub fn get_info_for_node(&self, node: &dyn Ranged) -> Option<Info> {
+        self.stored_infos.get(&node.lo()).map(|x| x.to_owned())
     }
 
     pub fn mark_disable_indent_for_next_bin_expr(&mut self) {

--- a/packages/rust-dprint-plugin-typescript/tests/test.rs
+++ b/packages/rust-dprint-plugin-typescript/tests/test.rs
@@ -17,6 +17,7 @@ struct FailedTestResult {
     message: String,
 }
 
+#[test]
 fn test_performance() {
     // run this with `cargo test --release -- --nocapture`
 
@@ -41,8 +42,7 @@ fn test_performance() {
         let result = format_text("checker.ts", &file_text, &config).expect("Could not parse...");
         let result = if let Some(result) = result { result } else { file_text.clone() };
 
-        let elapsed = start.elapsed();
-        println!("{}ms", elapsed.as_millis());
+        println!("{}ms", start.elapsed().as_millis());
         println!("---");
 
         if i == 0 {
@@ -51,7 +51,6 @@ fn test_performance() {
     }
 }
 
-#[test]
 fn test_specs() {
     let specs = get_specs();
     let test_count = specs.len();

--- a/packages/rust-dprint-plugin-typescript/tests/test.rs
+++ b/packages/rust-dprint-plugin-typescript/tests/test.rs
@@ -61,7 +61,7 @@ fn test_specs() {
         let config = resolve_config(&spec.config, &mut diagnostics);
         ensure_no_diagnostics(&diagnostics);
 
-        println!("FILE PATH: {}", file_path);
+        //debug_here!();
 
         let result = format_text(&spec.file_name, &spec.file_text, &config)
             .expect(format!("Could not parse spec '{}' in {}", spec.message, file_path).as_str());

--- a/packages/rust-dprint-plugin-typescript/tests/test.rs
+++ b/packages/rust-dprint-plugin-typescript/tests/test.rs
@@ -17,7 +17,6 @@ struct FailedTestResult {
     message: String,
 }
 
-#[test]
 fn test_performance() {
     // run this with `cargo test --release -- --nocapture`
 
@@ -51,6 +50,7 @@ fn test_performance() {
     }
 }
 
+#[test]
 fn test_specs() {
     let specs = get_specs();
     let test_count = specs.len();
@@ -60,6 +60,8 @@ fn test_specs() {
         let mut diagnostics = Vec::new();
         let config = resolve_config(&spec.config, &mut diagnostics);
         ensure_no_diagnostics(&diagnostics);
+
+        println!("FILE PATH: {}", file_path);
 
         let result = format_text(&spec.file_name, &spec.file_text, &config)
             .expect(format!("Could not parse spec '{}' in {}", spec.message, file_path).as_str());


### PR DESCRIPTION
This is faster and formats checker.ts in ~772ms.

1. A graph was being constructed on top of the parsed vectors. This graph generation was pushed up to the parsing stage so only one data structure needed to be created.
2. Resolved condition values are now only stored in the printer if someone gets a reference to a condition, which can then be used in a condition resolver. This saves a lot of time and needless memory usage.
3. In the implementation, UnsafeCell is used instead of RefCell. This is made "safe" by hiding away the use of UnsafeCell.
4. Indent "write items" are now stored with a count value. Previously it was pushing a single indent IR the number of times an indent was necessary.
5. This goes back to having the concept of "Signals" in the parsing, which I am very happy about.
6. Made `Info` and `ConditionReference` implement the `Copy` trait. These objects are extremely lightweight and doing the clones was unnecessary complexity.