### PR TITLE
Support "asserts" keyword without "is"

### DIFF
--- a/packages/rust-dprint-plugin-typescript/Cargo.toml
+++ b/packages/rust-dprint-plugin-typescript/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/dsherret/dprint"
 [dependencies]
 dprint-core = { path = "../rust-core", version = "0.10.0" }
 swc_common = "0.5.0"
-swc_ecma_ast = "0.16.0"
-swc_ecma_parser = "0.18.1"
+swc_ecma_ast = "0.17.0"
+swc_ecma_parser = "0.19.0"
 serde = { version = "1.0.88", features = ["derive"] }
 
 [dev-dependencies]

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -3530,7 +3530,7 @@ fn parse_type_predicate<'a>(node: &'a TsTypePredicate, context: &mut Context<'a>
     items.extend(parse_node((&node.param_name).into(), context));
     if let Some(type_ann) = &node.type_ann {
         items.push_str(" is ");
-        items.extend(parse_node((&node.type_ann).into(), context));
+        items.extend(parse_node(type_ann.into(), context));
     }
     return items;
 }

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -3496,8 +3496,10 @@ fn parse_type_predicate<'a>(node: &'a TsTypePredicate, context: &mut Context<'a>
     let mut items = PrintItems::new();
     if node.asserts { items.push_str("asserts "); }
     items.extend(parse_node((&node.param_name).into(), context));
-    items.push_str(" is ");
-    items.extend(parse_node((&node.type_ann).into(), context));
+    if let Some(type_ann) = &node.type_ann {
+        items.push_str(" is ");
+        items.extend(parse_node((&node.type_ann).into(), context));
+    }
     return items;
 }
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/types/TypePredicate/TypePredicate_All.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/types/TypePredicate/TypePredicate_All.txt
@@ -13,3 +13,27 @@ function test(c: any): asserts   c    is   string   {
 [expect]
 function test(c: any): asserts c is string {
 }
+
+== should format with asserts and no "is" ==
+function test(c: any): asserts   c    {
+}
+
+[expect]
+function test(c: any): asserts c {
+}
+
+== should format a "this" type predicate on a class declaration ==
+class C {
+    f(): void {}
+    g(): this is boolean { }
+    h(): asserts this is boolean { }
+    i(): asserts this { }
+}
+
+[expect]
+class C {
+    f(): void {}
+    g(): this is boolean {}
+    h(): asserts this is boolean {}
+    i(): asserts this {}
+}


### PR DESCRIPTION
Waiting on https://github.com/swc-project/swc/pull/667 and a release.

Closes #104