### PR TITLE
Improved semi-colon configuration

### DIFF
--- a/docs/home.md
+++ b/docs/home.md
@@ -151,11 +151,11 @@ Links:
 
 ### `semiColons`
 
-Whether to use semi-colons are not.
+Whether to use semi-colons.
 
-Note that when `semiColons` is `false` (or more specifically, when `"expressionStatement.semiColon"` is `false`), it will insert semi-colons at the beginning of some statements. Read why this is done here: https://standardjs.com/rules.html#semicolons
-
-Defaults to `true`.
+* `"always"` - Always uses semi-colons where applicable.
+* `"prefer"` - Prefers to use semi-colons, but doesn't add one in certain scenarios such as for the last member of a single-line type literal (default).
+* `"asi"` - Uses automatic semi-colon insertion. Only adds a semi-colon at the start of some expression statements when necessary. Read more: https://standardjs.com/rules.html#semicolons
 
 ### `quoteStyle`
 

--- a/packages/dprint-plugin-typescript/lib/dprint-plugin-typescript.d.ts
+++ b/packages/dprint-plugin-typescript/lib/dprint-plugin-typescript.d.ts
@@ -20,10 +20,15 @@ export interface TypeScriptConfiguration {
      */
     useTabs?: boolean;
     /**
-     * Whether statements should use semi-colons.
-     * @default true
+     * Whether semi-colons should be used.
+     * @default "prefer"
+     * @value "always" - Always uses semi-colons where applicable.
+     * @value "prefer" - Prefers to use semi-colons, but doesn't add one in certain scenarios
+     * such as for the last member of a single-line type literal.
+     * @value "asi" - Uses automatic semi-colon insertion. Only adds a semi-colon at the start
+     * of some expression statements when necessary.
      */
-    semiColons?: boolean;
+    semiColons?: "always" | "prefer" | "asi";
     /**
      * How to decide to use single or double quotes.
      * @default "preferDouble"
@@ -286,35 +291,6 @@ export interface TypeScriptConfiguration {
      * @value false - Ex. `while(true)`
      */
     "whileStatement.spaceAfterWhileKeyword"?: boolean;
-    "breakStatement.semiColon"?: boolean;
-    "callSignature.semiColon"?: boolean;
-    "classProperty.semiColon"?: boolean;
-    "constructor.semiColon"?: boolean;
-    "constructSignature.semiColon"?: boolean;
-    "continueStatement.semiColon"?: boolean;
-    "debuggerStatement.semiColon"?: boolean;
-    "doWhileStatement.semiColon"?: boolean;
-    "exportAllDeclaration.semiColon"?: boolean;
-    "exportAssignment.semiColon"?: boolean;
-    "exportDefaultExpression.semiColon"?: boolean;
-    "exportNamedDeclaration.semiColon"?: boolean;
-    "expressionStatement.semiColon"?: boolean;
-    "functionDeclaration.semiColon"?: boolean;
-    "getAccessor.semiColon"?: boolean;
-    "importDeclaration.semiColon"?: boolean;
-    "importEqualsDeclaration.semiColon"?: boolean;
-    "indexSignature.semiColon"?: boolean;
-    "mappedType.semiColon"?: boolean;
-    "method.semiColon"?: boolean;
-    "methodSignature.semiColon"?: boolean;
-    "moduleDeclaration.semiColon"?: boolean;
-    "namespaceExportDeclaration.semiColon"?: boolean;
-    "propertySignature.semiColon"?: boolean;
-    "returnStatement.semiColon"?: boolean;
-    "setAccessor.semiColon"?: boolean;
-    "throwStatement.semiColon"?: boolean;
-    "typeAlias.semiColon"?: boolean;
-    "variableStatement.semiColon"?: boolean;
     "forInStatement.useBraces"?: TypeScriptConfiguration["useBraces"];
     "forOfStatement.useBraces"?: TypeScriptConfiguration["useBraces"];
     "forStatement.useBraces"?: TypeScriptConfiguration["useBraces"];
@@ -384,35 +360,7 @@ export interface TypeScriptConfiguration {
  */
 export interface ResolvedTypeScriptConfiguration extends BaseResolvedConfiguration {
     readonly quoteStyle: NonNullable<TypeScriptConfiguration["quoteStyle"]>;
-    readonly "breakStatement.semiColon": boolean;
-    readonly "callSignature.semiColon": boolean;
-    readonly "classProperty.semiColon": boolean;
-    readonly "constructor.semiColon": boolean;
-    readonly "constructSignature.semiColon": boolean;
-    readonly "continueStatement.semiColon": boolean;
-    readonly "debuggerStatement.semiColon": boolean;
-    readonly "doWhileStatement.semiColon": boolean;
-    readonly "exportAllDeclaration.semiColon": boolean;
-    readonly "exportAssignment.semiColon": boolean;
-    readonly "exportDefaultExpression.semiColon": boolean;
-    readonly "exportNamedDeclaration.semiColon": boolean;
-    readonly "expressionStatement.semiColon": boolean;
-    readonly "functionDeclaration.semiColon": boolean;
-    readonly "getAccessor.semiColon": boolean;
-    readonly "importDeclaration.semiColon": boolean;
-    readonly "importEqualsDeclaration.semiColon": boolean;
-    readonly "indexSignature.semiColon": boolean;
-    readonly "mappedType.semiColon": boolean;
-    readonly "method.semiColon": boolean;
-    readonly "methodSignature.semiColon": boolean;
-    readonly "moduleDeclaration.semiColon": boolean;
-    readonly "namespaceExportDeclaration.semiColon": boolean;
-    readonly "propertySignature.semiColon": boolean;
-    readonly "setAccessor.semiColon": boolean;
-    readonly "returnStatement.semiColon": boolean;
-    readonly "throwStatement.semiColon": boolean;
-    readonly "typeAlias.semiColon": boolean;
-    readonly "variableStatement.semiColon": boolean;
+    readonly semiColons: NonNullable<TypeScriptConfiguration["semiColons"]>;
     readonly "forInStatement.useBraces": NonNullable<TypeScriptConfiguration["useBraces"]>;
     readonly "forOfStatement.useBraces": NonNullable<TypeScriptConfiguration["useBraces"]>;
     readonly "forStatement.useBraces": NonNullable<TypeScriptConfiguration["useBraces"]>;

--- a/packages/dprint-plugin-typescript/src/Configuration.ts
+++ b/packages/dprint-plugin-typescript/src/Configuration.ts
@@ -21,9 +21,14 @@ export interface TypeScriptConfiguration {
     useTabs?: boolean;
     /**
      * Whether statements should use semi-colons.
-     * @default true
+     * @default "prefer"
+     * @value "always" - Always uses semi-colons where applicable.
+     * @value "prefer" - Prefers to use semi-colons, but doesn't add one in certain scenarios
+     * such as for the last member of a single-line type element.
+     * @value "asi" - Uses automatic semi-colon insertion. Only adds a semi-colon at the start
+     * of some expression statements when necessary.
      */
-    semiColons?: boolean;
+    semiColons?: "always" | "prefer" | "asi";
     /**
      * How to decide to use single or double quotes.
      * @default "preferDouble"
@@ -290,35 +295,7 @@ export interface TypeScriptConfiguration {
      */
     "whileStatement.spaceAfterWhileKeyword"?: boolean;
 
-    "breakStatement.semiColon"?: boolean;
-    "callSignature.semiColon"?: boolean;
-    "classProperty.semiColon"?: boolean;
-    "constructor.semiColon"?: boolean;
-    "constructSignature.semiColon"?: boolean;
-    "continueStatement.semiColon"?: boolean;
-    "debuggerStatement.semiColon"?: boolean;
-    "doWhileStatement.semiColon"?: boolean;
-    "exportAllDeclaration.semiColon"?: boolean;
-    "exportAssignment.semiColon"?: boolean;
-    "exportDefaultExpression.semiColon"?: boolean;
-    "exportNamedDeclaration.semiColon"?: boolean;
-    "expressionStatement.semiColon"?: boolean;
-    "functionDeclaration.semiColon"?: boolean;
-    "getAccessor.semiColon"?: boolean;
-    "importDeclaration.semiColon"?: boolean;
-    "importEqualsDeclaration.semiColon"?: boolean;
-    "indexSignature.semiColon"?: boolean;
-    "mappedType.semiColon"?: boolean;
-    "method.semiColon"?: boolean;
-    "methodSignature.semiColon"?: boolean;
-    "moduleDeclaration.semiColon"?: boolean;
-    "namespaceExportDeclaration.semiColon"?: boolean;
-    "propertySignature.semiColon"?: boolean;
-    "returnStatement.semiColon"?: boolean;
-    "setAccessor.semiColon"?: boolean;
-    "throwStatement.semiColon"?: boolean;
-    "typeAlias.semiColon"?: boolean;
-    "variableStatement.semiColon"?: boolean;
+    "typeLiteral.semiColons"?: TypeScriptConfiguration["semiColons"];
 
     "forInStatement.useBraces"?: TypeScriptConfiguration["useBraces"];
     "forOfStatement.useBraces"?: TypeScriptConfiguration["useBraces"];
@@ -397,37 +374,10 @@ export interface TypeScriptConfiguration {
  */
 export interface ResolvedTypeScriptConfiguration extends BaseResolvedConfiguration {
     readonly quoteStyle: NonNullable<TypeScriptConfiguration["quoteStyle"]>;
+    readonly semiColons: NonNullable<TypeScriptConfiguration["semiColons"]>;
 
     // semi colons
-    readonly "breakStatement.semiColon": boolean;
-    readonly "callSignature.semiColon": boolean;
-    readonly "classProperty.semiColon": boolean;
-    readonly "constructor.semiColon": boolean;
-    readonly "constructSignature.semiColon": boolean;
-    readonly "continueStatement.semiColon": boolean;
-    readonly "debuggerStatement.semiColon": boolean;
-    readonly "doWhileStatement.semiColon": boolean;
-    readonly "exportAllDeclaration.semiColon": boolean;
-    readonly "exportAssignment.semiColon": boolean;
-    readonly "exportDefaultExpression.semiColon": boolean;
-    readonly "exportNamedDeclaration.semiColon": boolean;
-    readonly "expressionStatement.semiColon": boolean;
-    readonly "functionDeclaration.semiColon": boolean;
-    readonly "getAccessor.semiColon": boolean;
-    readonly "importDeclaration.semiColon": boolean;
-    readonly "importEqualsDeclaration.semiColon": boolean;
-    readonly "indexSignature.semiColon": boolean;
-    readonly "mappedType.semiColon": boolean;
-    readonly "method.semiColon": boolean;
-    readonly "methodSignature.semiColon": boolean;
-    readonly "moduleDeclaration.semiColon": boolean;
-    readonly "namespaceExportDeclaration.semiColon": boolean;
-    readonly "propertySignature.semiColon": boolean;
-    readonly "setAccessor.semiColon": boolean;
-    readonly "returnStatement.semiColon": boolean;
-    readonly "throwStatement.semiColon": boolean;
-    readonly "typeAlias.semiColon": boolean;
-    readonly "variableStatement.semiColon": boolean;
+    readonly "typeLiteral.semiColons": NonNullable<TypeScriptConfiguration["semiColons"]>;
 
     // use braces
     readonly "forInStatement.useBraces": NonNullable<TypeScriptConfiguration["useBraces"]>;

--- a/packages/dprint-plugin-typescript/src/Configuration.ts
+++ b/packages/dprint-plugin-typescript/src/Configuration.ts
@@ -20,11 +20,11 @@ export interface TypeScriptConfiguration {
      */
     useTabs?: boolean;
     /**
-     * Whether statements should use semi-colons.
+     * Whether semi-colons should be used.
      * @default "prefer"
      * @value "always" - Always uses semi-colons where applicable.
      * @value "prefer" - Prefers to use semi-colons, but doesn't add one in certain scenarios
-     * such as for the last member of a single-line type element.
+     * such as for the last member of a single-line type literal.
      * @value "asi" - Uses automatic semi-colon insertion. Only adds a semi-colon at the start
      * of some expression statements when necessary.
      */
@@ -295,8 +295,6 @@ export interface TypeScriptConfiguration {
      */
     "whileStatement.spaceAfterWhileKeyword"?: boolean;
 
-    "typeLiteral.semiColons"?: TypeScriptConfiguration["semiColons"];
-
     "forInStatement.useBraces"?: TypeScriptConfiguration["useBraces"];
     "forOfStatement.useBraces"?: TypeScriptConfiguration["useBraces"];
     "forStatement.useBraces"?: TypeScriptConfiguration["useBraces"];
@@ -375,9 +373,6 @@ export interface TypeScriptConfiguration {
 export interface ResolvedTypeScriptConfiguration extends BaseResolvedConfiguration {
     readonly quoteStyle: NonNullable<TypeScriptConfiguration["quoteStyle"]>;
     readonly semiColons: NonNullable<TypeScriptConfiguration["semiColons"]>;
-
-    // semi colons
-    readonly "typeLiteral.semiColons": NonNullable<TypeScriptConfiguration["semiColons"]>;
 
     // use braces
     readonly "forInStatement.useBraces": NonNullable<TypeScriptConfiguration["useBraces"]>;

--- a/packages/dprint-plugin-typescript/src/tests/configurationTests.ts
+++ b/packages/dprint-plugin-typescript/src/tests/configurationTests.ts
@@ -50,9 +50,9 @@ describe("configuration", () => {
         });
 
         it("should do a diagnostic when providing an incorrect boolean value", () => {
-            doTest({ semiColons: 5 as any as boolean }, {}, () => false, [{
-                message: "Error parsing configuration value for 'semiColons'. Message: provided string was not `true` or `false`",
-                propertyName: "semiColons"
+            doTest({ "setAccessor.spaceBeforeParentheses": 5 as any as boolean }, {}, () => false, [{
+                message: "Error parsing configuration value for 'setAccessor.spaceBeforeParentheses'. Message: provided string was not `true` or `false`",
+                propertyName: "setAccessor.spaceBeforeParentheses"
             }]);
         });
 
@@ -66,59 +66,33 @@ describe("configuration", () => {
 
     describe(nameof<TypeScriptConfiguration>(c => c.semiColons), () => {
         function doSpecificTest(config: TypeScriptConfiguration, expectedConfig: Partial<ResolvedTypeScriptConfiguration>) {
-            doTest(config, expectedConfig, prop => prop.endsWith("semiColon"));
+            doTest(config, expectedConfig, prop => prop.endsWith("semiColons"));
         }
 
         it("should set all the semi-colon values using the default", () => {
-            doSpecificTest({}, getObject(true));
+            doSpecificTest({}, getObject("prefer"));
         });
 
         it("should set all the semi-colon values when using the default", () => {
-            doSpecificTest({ semiColons: true }, getObject(true));
+            doSpecificTest({ semiColons: "prefer" }, getObject("prefer"));
         });
 
         it("should set all the semi-colon values when set to a non-default", () => {
-            doSpecificTest({ semiColons: false }, getObject(false));
+            doSpecificTest({ semiColons: "asi" }, getObject("asi"));
         });
 
         it("should allow setting specific values when not the default", () => {
-            const expectedConfig = getObject(false);
+            const expectedConfig = getObject("always");
+            (expectedConfig as any).semiColons = "prefer"
             const config: TypeScriptConfiguration = { ...expectedConfig } as any;
-            config.semiColons = true;
+            config.semiColons = "prefer";
             doSpecificTest(config, expectedConfig);
         });
 
-        function getObject(value: boolean): Partial<ResolvedTypeScriptConfiguration> {
+        function getObject(value: NonNullable<TypeScriptConfiguration["semiColons"]>): Partial<ResolvedTypeScriptConfiguration> {
             return {
-                "breakStatement.semiColon": value,
-                "callSignature.semiColon": value,
-                "classProperty.semiColon": value,
-                "constructor.semiColon": value,
-                "constructSignature.semiColon": value,
-                "continueStatement.semiColon": value,
-                "debuggerStatement.semiColon": value,
-                "doWhileStatement.semiColon": value,
-                "exportAllDeclaration.semiColon": value,
-                "exportAssignment.semiColon": value,
-                "exportDefaultExpression.semiColon": value,
-                "exportNamedDeclaration.semiColon": value,
-                "expressionStatement.semiColon": value,
-                "functionDeclaration.semiColon": value,
-                "getAccessor.semiColon": value,
-                "importDeclaration.semiColon": value,
-                "importEqualsDeclaration.semiColon": value,
-                "indexSignature.semiColon": value,
-                "mappedType.semiColon": value,
-                "method.semiColon": value,
-                "methodSignature.semiColon": value,
-                "moduleDeclaration.semiColon": value,
-                "namespaceExportDeclaration.semiColon": value,
-                "propertySignature.semiColon": value,
-                "returnStatement.semiColon": value,
-                "setAccessor.semiColon": value,
-                "throwStatement.semiColon": value,
-                "typeAlias.semiColon": value,
-                "variableStatement.semiColon": value
+                semiColons: value,
+                "typeLiteral.semiColons": value,
             };
         }
     });

--- a/packages/dprint-plugin-typescript/src/tests/configurationTests.ts
+++ b/packages/dprint-plugin-typescript/src/tests/configurationTests.ts
@@ -65,36 +65,22 @@ describe("configuration", () => {
     });
 
     describe(nameof<TypeScriptConfiguration>(c => c.semiColons), () => {
-        function doSpecificTest(config: TypeScriptConfiguration, expectedConfig: Partial<ResolvedTypeScriptConfiguration>) {
-            doTest(config, expectedConfig, prop => prop.endsWith("semiColons"));
+        function doSpecificTest(value: TypeScriptConfiguration["semiColons"] | undefined, expectedValue: ResolvedTypeScriptConfiguration["semiColons"]) {
+            doTest({ semiColons: value }, { semiColons: expectedValue }, prop => prop === "semiColons");
         }
 
-        it("should set all the semi-colon values using the default", () => {
-            doSpecificTest({}, getObject("prefer"));
+        it("should set when not set", () => {
+            doSpecificTest(undefined, "prefer");
         });
 
-        it("should set all the semi-colon values when using the default", () => {
-            doSpecificTest({ semiColons: "prefer" }, getObject("prefer"));
+        it("should use when set to the default", () => {
+            doSpecificTest("prefer", "prefer");
         });
 
-        it("should set all the semi-colon values when set to a non-default", () => {
-            doSpecificTest({ semiColons: "asi" }, getObject("asi"));
+        it("should use when not set to the default", () => {
+            doSpecificTest("always", "always");
+            doSpecificTest("asi", "asi");
         });
-
-        it("should allow setting specific values when not the default", () => {
-            const expectedConfig = getObject("always");
-            (expectedConfig as any).semiColons = "prefer"
-            const config: TypeScriptConfiguration = { ...expectedConfig } as any;
-            config.semiColons = "prefer";
-            doSpecificTest(config, expectedConfig);
-        });
-
-        function getObject(value: NonNullable<TypeScriptConfiguration["semiColons"]>): Partial<ResolvedTypeScriptConfiguration> {
-            return {
-                semiColons: value,
-                "typeLiteral.semiColons": value,
-            };
-        }
     });
 
     describe(nameof<TypeScriptConfiguration>(c => c.quoteStyle), () => {

--- a/packages/playground/src/Playground.tsx
+++ b/packages/playground/src/Playground.tsx
@@ -36,7 +36,7 @@ export class Playground extends React.Component<PlaygroundProps, PlaygroundState
             lineWidth: initialConfig.lineWidth,
             indentWidth: initialConfig.indentWidth,
             useTabs: initialConfig.useTabs,
-            semiColons: initialConfig["breakStatement.semiColon"],
+            semiColons: initialConfig.semiColons,
             quoteStyle: initialConfig.quoteStyle,
             trailingCommas: initialConfig["tupleType.trailingCommas"],
             useBraces: initialConfig["ifStatement.useBraces"],

--- a/packages/playground/src/components/ConfigurationSelection.tsx
+++ b/packages/playground/src/components/ConfigurationSelection.tsx
@@ -8,6 +8,8 @@ export interface ConfigurationSelectionProps {
     onUpdateConfig: (config: TypeScriptConfiguration) => void;
 }
 
+const semiColonsOptions = ["always", "prefer", "asi"] as const;
+type _assertSemiColons = AssertTrue<IsExact<typeof semiColonsOptions[number], NonNullable<TypeScriptConfiguration["semiColons"]>>>;
 const quoteStyleOptions = ["alwaysDouble", "alwaysSingle", "preferDouble", "preferSingle"] as const;
 type _assertQuoteStyleOptions = AssertTrue<IsExact<typeof quoteStyleOptions[number],
     NonNullable<TypeScriptConfiguration["quoteStyle"]>>>;
@@ -45,7 +47,7 @@ export class ConfigurationSelection extends React.Component<ConfigurationSelecti
                 {this.getBooleanConfig("useTabs")}
             </ConfigurationItem>
             <ConfigurationItem title="Semicolons">
-                {this.getBooleanConfig("semiColons")}
+                {this.getSelectForConfig("semiColons", semiColonsOptions)}
             </ConfigurationItem>
             <ConfigurationItem title="Quote style">
                 {this.getSelectForConfig("quoteStyle", quoteStyleOptions)}

--- a/packages/rust-dprint-plugin-typescript/src/configuration.rs
+++ b/packages/rust-dprint-plugin-typescript/src/configuration.rs
@@ -86,8 +86,8 @@ impl ConfigurationBuilder {
 
     /// Whether statements should end in a semi-colon.
     ///
-    /// Default: `true`
-    pub fn semi_colons(&mut self, value: bool) -> &mut Self {
+    /// Default: `SemiColons::Prefer`
+    pub fn semi_colons(&mut self, value: SemiColons) -> &mut Self {
         self.insert("semiColons", value)
     }
 
@@ -547,122 +547,10 @@ impl ConfigurationBuilder {
         self.insert("conditionalExpression.operatorPosition", value)
     }
 
-    /* semi-colon */
+    /* semi-colons */
 
-    pub fn break_statement_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("breakStatement.semiColon", value)
-    }
-
-    pub fn call_signature_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("callSignature.semiColon", value)
-    }
-
-    pub fn class_property_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("classProperty.semiColon", value)
-    }
-
-    pub fn construct_signature_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("constructSignature.semiColon", value)
-    }
-
-    pub fn constructor_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("constructor.semiColon", value)
-    }
-
-    pub fn continue_statement_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("continueStatement.semiColon", value)
-    }
-
-    pub fn debugger_statement_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("debuggerStatement.semiColon", value)
-    }
-
-    pub fn do_while_statement_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("doWhileStatement.semiColon", value)
-    }
-
-    pub fn export_all_declaration_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("exportAllDeclaration.semiColon", value)
-    }
-
-    pub fn export_assignment_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("exportAssignment.semiColon", value)
-    }
-
-    pub fn export_default_expression_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("exportDefaultExpression.semiColon", value)
-    }
-
-    pub fn export_named_declaration_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("exportNamedDeclaration.semiColon", value)
-    }
-
-    pub fn expression_statement_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("expressionStatement.semiColon", value)
-    }
-
-    pub fn function_declaration_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("functionDeclaration.semiColon", value)
-    }
-
-    pub fn get_accessor_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("getAccessor.semiColon", value)
-    }
-
-    pub fn import_declaration_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("importDeclaration.semiColon", value)
-    }
-
-    pub fn import_equals_declaration_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("importEqualsDeclaration.semiColon", value)
-    }
-
-    pub fn index_signature_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("indexSignature.semiColon", value)
-    }
-
-    pub fn mapped_type_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("mappedType.semiColon", value)
-    }
-
-    pub fn method_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("method.semiColon", value)
-    }
-
-    pub fn method_signature_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("methodSignature.semiColon", value)
-    }
-
-    pub fn module_declaration_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("moduleDeclaration.semiColon", value)
-    }
-
-    pub fn namespace_export_declaration_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("namespaceExportDeclaration.semiColon", value)
-    }
-
-    pub fn property_signature_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("propertySignature.semiColon", value)
-    }
-
-    pub fn return_statement_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("returnStatement.semiColon", value)
-    }
-
-    pub fn set_accessor_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("setAccessor.semiColon", value)
-    }
-
-    pub fn throw_statement_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("throwStatement.semiColon", value)
-    }
-
-    pub fn type_alias_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("typeAlias.semiColon", value)
-    }
-
-    pub fn variable_statement_semi_colon(&mut self, value: bool) -> &mut Self {
-        self.insert("variableStatement.semiColon", value)
+    pub fn type_literal_semi_colons(&mut self, value: SemiColons) -> &mut Self {
+        self.insert("typeLiteral.semiColons", value)
     }
 
     /* single body position */
@@ -763,6 +651,38 @@ macro_rules! generate_str_to_from {
         }
     };
 }
+
+
+/// Semi colon possibilities.
+#[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SemiColons {
+    /// Always uses semi-colons where applicable.
+    Always,
+    /// Prefers to use semi-colons, but doesn't add one in certain scenarios
+    /// such as for the last member of a single-line type element.
+    Prefer,
+    /// Uses automatic semi-colon insertion. Only adds a semi-colon at the start
+    /// of some expression statements when necessary.
+    Asi,
+}
+
+impl SemiColons {
+    /// Gets if this option is "Always" or "Prefer".
+    pub(super) fn is_true(&self) -> bool {
+        match self {
+            SemiColons::Always | SemiColons::Prefer => true,
+            SemiColons::Asi => false,
+        }
+    }
+}
+
+generate_str_to_from![
+    SemiColons,
+    [Always, "always"],
+    [Prefer, "prefer"],
+    [Asi, "asi"]
+];
 
 /// Trailing comma possibilities.
 #[derive(Clone, PartialEq, Copy, Serialize, Deserialize)]
@@ -974,7 +894,7 @@ pub fn resolve_config(config: &HashMap<String, String>, global_config: &GlobalCo
     let mut diagnostics = Vec::new();
     let mut config = config.clone();
 
-    let semi_colons = get_value(&mut config, "semiColons", true, &mut diagnostics);
+    let semi_colons = get_value(&mut config, "semiColons", SemiColons::Prefer, &mut diagnostics);
     let brace_position = get_value(&mut config, "bracePosition", BracePosition::NextLineIfHanging, &mut diagnostics);
     let next_control_flow_position = get_value(&mut config, "nextControlFlowPosition", NextControlFlowPosition::SameLine, &mut diagnostics);
     let operator_position = get_value(&mut config, "operatorPosition", OperatorPosition::NextLine, &mut diagnostics);
@@ -992,6 +912,7 @@ pub fn resolve_config(config: &HashMap<String, String>, global_config: &GlobalCo
         indent_width: get_value(&mut config, "indentWidth", global_config.indent_width.unwrap_or(DEFAULT_GLOBAL_CONFIGURATION.indent_width), &mut diagnostics),
         new_line_kind: get_value(&mut config, "newLineKind", global_config.new_line_kind.unwrap_or(DEFAULT_GLOBAL_CONFIGURATION.new_line_kind), &mut diagnostics),
         quote_style: get_value(&mut config, "quoteStyle", QuoteStyle::PreferDouble, &mut diagnostics),
+        semi_colons,
         /* use parentheses */
         arrow_function_expression_use_parentheses: get_value(&mut config, "arrowFunctionExpression.useParentheses", UseParentheses::Maintain, &mut diagnostics),
         /* brace position */
@@ -1049,36 +970,8 @@ pub fn resolve_config(config: &HashMap<String, String>, global_config: &GlobalCo
         /* operator position */
         binary_expression_operator_position: get_value(&mut config, "binaryExpression.operatorPosition", operator_position, &mut diagnostics),
         conditional_expression_operator_position: get_value(&mut config, "conditionalExpression.operatorPosition", operator_position, &mut diagnostics),
-        /* semi-colon */
-        break_statement_semi_colon: get_value(&mut config, "breakStatement.semiColon", semi_colons, &mut diagnostics),
-        call_signature_semi_colon: get_value(&mut config, "callSignature.semiColon", semi_colons, &mut diagnostics),
-        class_property_semi_colon: get_value(&mut config, "classProperty.semiColon", semi_colons, &mut diagnostics),
-        construct_signature_semi_colon: get_value(&mut config, "constructSignature.semiColon", semi_colons, &mut diagnostics),
-        constructor_semi_colon: get_value(&mut config, "constructor.semiColon", semi_colons, &mut diagnostics),
-        continue_statement_semi_colon: get_value(&mut config, "continueStatement.semiColon", semi_colons, &mut diagnostics),
-        debugger_statement_semi_colon: get_value(&mut config, "debuggerStatement.semiColon", semi_colons, &mut diagnostics),
-        do_while_statement_semi_colon: get_value(&mut config, "doWhileStatement.semiColon", semi_colons, &mut diagnostics),
-        export_all_declaration_semi_colon: get_value(&mut config, "exportAllDeclaration.semiColon", semi_colons, &mut diagnostics),
-        export_assignment_semi_colon: get_value(&mut config, "exportAssignment.semiColon", semi_colons, &mut diagnostics),
-        export_default_expression_semi_colon: get_value(&mut config, "exportDefaultExpression.semiColon", semi_colons, &mut diagnostics),
-        export_named_declaration_semi_colon: get_value(&mut config, "exportNamedDeclaration.semiColon", semi_colons, &mut diagnostics),
-        expression_statement_semi_colon: get_value(&mut config, "expressionStatement.semiColon", semi_colons, &mut diagnostics),
-        function_declaration_semi_colon: get_value(&mut config, "functionDeclaration.semiColon", semi_colons, &mut diagnostics),
-        get_accessor_semi_colon: get_value(&mut config, "getAccessor.semiColon", semi_colons, &mut diagnostics),
-        import_declaration_semi_colon: get_value(&mut config, "importDeclaration.semiColon", semi_colons, &mut diagnostics),
-        import_equals_declaration_semi_colon: get_value(&mut config, "importEqualsDeclaration.semiColon", semi_colons, &mut diagnostics),
-        index_signature_semi_colon: get_value(&mut config, "indexSignature.semiColon", semi_colons, &mut diagnostics),
-        mapped_type_semi_colon: get_value(&mut config, "mappedType.semiColon", semi_colons, &mut diagnostics),
-        method_semi_colon: get_value(&mut config, "method.semiColon", semi_colons, &mut diagnostics),
-        method_signature_semi_colon: get_value(&mut config, "methodSignature.semiColon", semi_colons, &mut diagnostics),
-        module_declaration_semi_colon: get_value(&mut config, "moduleDeclaration.semiColon", semi_colons, &mut diagnostics),
-        namespace_export_declaration_semi_colon: get_value(&mut config, "namespaceExportDeclaration.semiColon", semi_colons, &mut diagnostics),
-        property_signature_semi_colon: get_value(&mut config, "propertySignature.semiColon", semi_colons, &mut diagnostics),
-        return_statement_semi_colon: get_value(&mut config, "returnStatement.semiColon", semi_colons, &mut diagnostics),
-        set_accessor_semi_colon: get_value(&mut config, "setAccessor.semiColon", semi_colons, &mut diagnostics),
-        throw_statement_semi_colon: get_value(&mut config, "throwStatement.semiColon", semi_colons, &mut diagnostics),
-        type_alias_semi_colon: get_value(&mut config, "typeAlias.semiColon", semi_colons, &mut diagnostics),
-        variable_statement_semi_colon: get_value(&mut config, "variableStatement.semiColon", semi_colons, &mut diagnostics),
+        /* semi-colons */
+        type_literal_semi_colons: get_value(&mut config, "typeLiteral.semiColons", semi_colons, &mut diagnostics),
         /* single body position */
         if_statement_single_body_position: get_value(&mut config, "ifStatement.singleBodyPosition", single_body_position, &mut diagnostics),
         for_statement_single_body_position: get_value(&mut config, "forStatement.singleBodyPosition", single_body_position, &mut diagnostics),
@@ -1143,6 +1036,7 @@ pub struct Configuration {
     pub use_tabs: bool,
     pub new_line_kind: NewLineKind,
     pub quote_style: QuoteStyle,
+    pub semi_colons: SemiColons,
     /* use parentheses */
     #[serde(rename = "arrowFunctionExpression.useParentheses")]
     pub arrow_function_expression_use_parentheses: UseParentheses,
@@ -1249,65 +1143,9 @@ pub struct Configuration {
     pub binary_expression_operator_position: OperatorPosition,
     #[serde(rename = "conditionalExpression.operatorPosition")]
     pub conditional_expression_operator_position: OperatorPosition,
-    /* semi-colon */
-    #[serde(rename = "breakStatement.semiColon")]
-    pub break_statement_semi_colon: bool,
-    #[serde(rename = "callSignature.semiColon")]
-    pub call_signature_semi_colon: bool,
-    #[serde(rename = "classProperty.semiColon")]
-    pub class_property_semi_colon: bool,
-    #[serde(rename = "constructSignature.semiColon")]
-    pub construct_signature_semi_colon: bool,
-    #[serde(rename = "constructor.semiColon")]
-    pub constructor_semi_colon: bool,
-    #[serde(rename = "continueStatement.semiColon")]
-    pub continue_statement_semi_colon: bool,
-    #[serde(rename = "debuggerStatement.semiColon")]
-    pub debugger_statement_semi_colon: bool,
-    #[serde(rename = "doWhileStatement.semiColon")]
-    pub do_while_statement_semi_colon: bool,
-    #[serde(rename = "exportAllDeclaration.semiColon")]
-    pub export_all_declaration_semi_colon: bool,
-    #[serde(rename = "exportAssignment.semiColon")]
-    pub export_assignment_semi_colon: bool,
-    #[serde(rename = "exportDefaultExpression.semiColon")]
-    pub export_default_expression_semi_colon: bool,
-    #[serde(rename = "exportNamedDeclaration.semiColon")]
-    pub export_named_declaration_semi_colon: bool,
-    #[serde(rename = "expressionStatement.semiColon")]
-    pub expression_statement_semi_colon: bool,
-    #[serde(rename = "functionDeclaration.semiColon")]
-    pub function_declaration_semi_colon: bool,
-    #[serde(rename = "getAccessor.semiColon")]
-    pub get_accessor_semi_colon: bool,
-    #[serde(rename = "importDeclaration.semiColon")]
-    pub import_declaration_semi_colon: bool,
-    #[serde(rename = "importEqualsDeclaration.semiColon")]
-    pub import_equals_declaration_semi_colon: bool,
-    #[serde(rename = "indexSignature.semiColon")]
-    pub index_signature_semi_colon: bool,
-    #[serde(rename = "mappedType.semiColon")]
-    pub mapped_type_semi_colon: bool,
-    #[serde(rename = "method.semiColon")]
-    pub method_semi_colon: bool,
-    #[serde(rename = "methodSignature.semiColon")]
-    pub method_signature_semi_colon: bool,
-    #[serde(rename = "moduleDeclaration.semiColon")]
-    pub module_declaration_semi_colon: bool,
-    #[serde(rename = "namespaceExportDeclaration.semiColon")]
-    pub namespace_export_declaration_semi_colon: bool,
-    #[serde(rename = "propertySignature.semiColon")]
-    pub property_signature_semi_colon: bool,
-    #[serde(rename = "returnStatement.semiColon")]
-    pub return_statement_semi_colon: bool,
-    #[serde(rename = "setAccessor.semiColon")]
-    pub set_accessor_semi_colon: bool,
-    #[serde(rename = "throwStatement.semiColon")]
-    pub throw_statement_semi_colon: bool,
-    #[serde(rename = "typeAlias.semiColon")]
-    pub type_alias_semi_colon: bool,
-    #[serde(rename = "variableStatement.semiColon")]
-    pub variable_statement_semi_colon: bool,
+    /* semi-colons */
+    #[serde(rename = "typeLiteral.semiColons")]
+    pub type_literal_semi_colons: SemiColons,
     /* single body position */
     #[serde(rename = "ifStatement.singleBodyPosition")]
     pub if_statement_single_body_position: SingleBodyPosition,

--- a/packages/rust-dprint-plugin-typescript/src/configuration.rs
+++ b/packages/rust-dprint-plugin-typescript/src/configuration.rs
@@ -547,12 +547,6 @@ impl ConfigurationBuilder {
         self.insert("conditionalExpression.operatorPosition", value)
     }
 
-    /* semi-colons */
-
-    pub fn type_literal_semi_colons(&mut self, value: SemiColons) -> &mut Self {
-        self.insert("typeLiteral.semiColons", value)
-    }
-
     /* single body position */
     pub fn if_statement_single_body_position(&mut self, value: SingleBodyPosition) -> &mut Self {
         self.insert("ifStatement.singleBodyPosition", value)
@@ -660,7 +654,7 @@ pub enum SemiColons {
     /// Always uses semi-colons where applicable.
     Always,
     /// Prefers to use semi-colons, but doesn't add one in certain scenarios
-    /// such as for the last member of a single-line type element.
+    /// such as for the last member of a single-line type literal.
     Prefer,
     /// Uses automatic semi-colon insertion. Only adds a semi-colon at the start
     /// of some expression statements when necessary.
@@ -970,8 +964,6 @@ pub fn resolve_config(config: &HashMap<String, String>, global_config: &GlobalCo
         /* operator position */
         binary_expression_operator_position: get_value(&mut config, "binaryExpression.operatorPosition", operator_position, &mut diagnostics),
         conditional_expression_operator_position: get_value(&mut config, "conditionalExpression.operatorPosition", operator_position, &mut diagnostics),
-        /* semi-colons */
-        type_literal_semi_colons: get_value(&mut config, "typeLiteral.semiColons", semi_colons, &mut diagnostics),
         /* single body position */
         if_statement_single_body_position: get_value(&mut config, "ifStatement.singleBodyPosition", single_body_position, &mut diagnostics),
         for_statement_single_body_position: get_value(&mut config, "forStatement.singleBodyPosition", single_body_position, &mut diagnostics),
@@ -1143,9 +1135,6 @@ pub struct Configuration {
     pub binary_expression_operator_position: OperatorPosition,
     #[serde(rename = "conditionalExpression.operatorPosition")]
     pub conditional_expression_operator_position: OperatorPosition,
-    /* semi-colons */
-    #[serde(rename = "typeLiteral.semiColons")]
-    pub type_literal_semi_colons: SemiColons,
     /* single body position */
     #[serde(rename = "ifStatement.singleBodyPosition")]
     pub if_statement_single_body_position: SingleBodyPosition,

--- a/packages/rust-dprint-plugin-typescript/src/configuration_tests.rs
+++ b/packages/rust-dprint-plugin-typescript/src/configuration_tests.rs
@@ -78,8 +78,6 @@ fn check_all_values_set() {
         /* operator position */
         .binary_expression_operator_position(OperatorPosition::SameLine)
         .conditional_expression_operator_position(OperatorPosition::SameLine)
-        /* semi-colons */
-        .type_literal_semi_colons(SemiColons::Always)
         /* single body position */
         .if_statement_single_body_position(SingleBodyPosition::SameLine)
         .for_statement_single_body_position(SingleBodyPosition::SameLine)
@@ -123,7 +121,7 @@ fn check_all_values_set() {
         .while_statement_space_after_while_keyword(true);
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 101);
+    assert_eq!(inner_config.len(), 100);
     let diagnostics = resolve_config(&inner_config, &resolve_global_config(&HashMap::new()).config).diagnostics;
     assert_eq!(diagnostics.len(), 0);
 }

--- a/packages/rust-dprint-plugin-typescript/src/configuration_tests.rs
+++ b/packages/rust-dprint-plugin-typescript/src/configuration_tests.rs
@@ -11,7 +11,7 @@ fn check_all_values_set() {
         .indent_width(4)
         /* common */
         .quote_style(QuoteStyle::AlwaysDouble)
-        .semi_colons(true)
+        .semi_colons(SemiColons::Prefer)
         .brace_position(BracePosition::NextLine)
         .next_control_flow_position(NextControlFlowPosition::SameLine)
         .operator_position(OperatorPosition::SameLine)
@@ -78,36 +78,8 @@ fn check_all_values_set() {
         /* operator position */
         .binary_expression_operator_position(OperatorPosition::SameLine)
         .conditional_expression_operator_position(OperatorPosition::SameLine)
-        /* semi-colon */
-        .break_statement_semi_colon(true)
-        .call_signature_semi_colon(true)
-        .class_property_semi_colon(true)
-        .construct_signature_semi_colon(true)
-        .constructor_semi_colon(true)
-        .continue_statement_semi_colon(true)
-        .debugger_statement_semi_colon(true)
-        .do_while_statement_semi_colon(true)
-        .export_all_declaration_semi_colon(true)
-        .export_assignment_semi_colon(true)
-        .export_default_expression_semi_colon(true)
-        .export_named_declaration_semi_colon(true)
-        .expression_statement_semi_colon(true)
-        .function_declaration_semi_colon(true)
-        .get_accessor_semi_colon(true)
-        .import_declaration_semi_colon(true)
-        .import_equals_declaration_semi_colon(true)
-        .index_signature_semi_colon(true)
-        .mapped_type_semi_colon(true)
-        .method_semi_colon(true)
-        .method_signature_semi_colon(true)
-        .module_declaration_semi_colon(true)
-        .namespace_export_declaration_semi_colon(true)
-        .property_signature_semi_colon(true)
-        .return_statement_semi_colon(true)
-        .set_accessor_semi_colon(true)
-        .throw_statement_semi_colon(true)
-        .type_alias_semi_colon(true)
-        .variable_statement_semi_colon(true)
+        /* semi-colons */
+        .type_literal_semi_colons(SemiColons::Always)
         /* single body position */
         .if_statement_single_body_position(SingleBodyPosition::SameLine)
         .for_statement_single_body_position(SingleBodyPosition::SameLine)
@@ -151,7 +123,7 @@ fn check_all_values_set() {
         .while_statement_space_after_while_keyword(true);
 
     let inner_config = config.get_inner_config();
-    assert_eq!(inner_config.len(), 129);
+    assert_eq!(inner_config.len(), 101);
     let diagnostics = resolve_config(&inner_config, &resolve_global_config(&HashMap::new()).config).diagnostics;
     assert_eq!(diagnostics.len(), 0);
 }

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -462,7 +462,7 @@ fn parse_class_prop_common<'a>(node: ParseClassPropCommon<'a>, context: &mut Con
         items.push_condition(conditions::indent_if_start_of_line(parse_node(value.into(), context)));
     }
 
-    if context.config.class_property_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -652,7 +652,7 @@ fn parse_export_default_expr<'a>(node: &'a ExportDefaultExpr, context: &mut Cont
     let mut items = PrintItems::new();
     items.push_str("export default ");
     items.extend(parse_node((&node.expr).into(), context));
-    if context.config.export_default_expression_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
     items
 }
 
@@ -748,7 +748,7 @@ fn parse_export_named_decl<'a>(node: &'a NamedExport, context: &mut Context<'a>)
         items.extend(parse_node(src.into(), context));
     }
 
-    if context.config.export_named_declaration_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -818,7 +818,7 @@ fn parse_function_decl_or_expr<'a>(node: FunctionDeclOrExprNode<'a>, context: &m
 
         items.extend(parse_node(body.into(), context));
     } else {
-        if context.config.function_declaration_semi_colon {
+        if context.config.semi_colons.is_true() {
             items.push_str(";");
         }
     }
@@ -875,7 +875,7 @@ fn parse_import_decl<'a>(node: &'a ImportDecl, context: &mut Context<'a>) -> Pri
 
     items.extend(parse_node((&node.src).into(), context));
 
-    if context.config.import_declaration_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -893,7 +893,7 @@ fn parse_import_equals_decl<'a>(node: &'a TsImportEqualsDecl, context: &mut Cont
     items.push_str(" = ");
     items.extend(parse_node((&node.module_ref).into(), context));
 
-    if context.config.import_equals_declaration_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -983,7 +983,7 @@ fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: 
                 }
             }
         }
-        else if context.config.module_declaration_semi_colon {
+        else if context.config.semi_colons.is_true() {
             items.push_str(";");
         }
 
@@ -1002,7 +1002,7 @@ fn parse_type_alias<'a>(node: &'a TsTypeAliasDecl, context: &mut Context<'a>) ->
     items.push_str(" = ");
     items.extend(parse_node((&node.type_ann).into(), context));
 
-    if context.config.type_alias_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -1907,7 +1907,7 @@ fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Co
             type_node_separator: None,
         }, context)),
     }, context));
-    if context.config.call_signature_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -1929,7 +1929,7 @@ fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, contex
             type_node_separator: None,
         }, context)),
     }, context));
-    if context.config.construct_signature_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -1944,7 +1944,7 @@ fn parse_index_signature<'a>(node: &'a TsIndexSignature, context: &mut Context<'
     items.extend(parse_node(node.params.iter().next().expect("Expected the index signature to have one parameter.").into(), context));
     items.push_str("]");
     items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    if context.config.index_signature_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -1994,7 +1994,7 @@ fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context
         }, context)),
     }, context));
 
-    if context.config.method_signature_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -2018,7 +2018,7 @@ fn parse_property_signature<'a>(node: &'a TsPropertySignature, context: &mut Con
         }));
     }
 
-    if context.config.property_signature_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -2500,7 +2500,7 @@ fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut
             start_header_info: Some(start_header_info),
         }, context));
         items.extend(parse_node(body, context));
-    } else if get_use_semi_colon(&node.kind, context) {
+    } else if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -2530,15 +2530,6 @@ fn parse_class_or_object_method<'a>(node: ClassOrObjectMethod<'a>, context: &mut
             ClassOrObjectMethodKind::Getter => context.config.get_accessor_brace_position,
             ClassOrObjectMethodKind::Setter => context.config.set_accessor_brace_position,
             ClassOrObjectMethodKind::Method => context.config.method_brace_position,
-        }
-    }
-
-    fn get_use_semi_colon(kind: &ClassOrObjectMethodKind, context: &mut Context) -> bool {
-        match kind {
-            ClassOrObjectMethodKind::Constructor => context.config.constructor_semi_colon,
-            ClassOrObjectMethodKind::Getter => context.config.get_accessor_semi_colon,
-            ClassOrObjectMethodKind::Setter => context.config.set_accessor_semi_colon,
-            ClassOrObjectMethodKind::Method => context.config.method_semi_colon,
         }
     }
 }
@@ -2613,7 +2604,7 @@ fn parse_break_stmt<'a>(node: &'a BreakStmt, context: &mut Context<'a>) -> Print
         items.push_str(" ");
         items.extend(parse_node(label.into(), context));
     }
-    if context.config.break_statement_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -2628,7 +2619,7 @@ fn parse_continue_stmt<'a>(node: &'a ContinueStmt, context: &mut Context<'a>) ->
         items.push_str(" ");
         items.extend(parse_node(label.into(), context));
     }
-    if context.config.continue_statement_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -2639,7 +2630,7 @@ fn parse_debugger_stmt<'a>(_: &'a DebuggerStmt, context: &mut Context<'a>) -> Pr
     let mut items = PrintItems::new();
 
     items.push_str("debugger");
-    if context.config.debugger_statement_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -2661,7 +2652,7 @@ fn parse_do_while_stmt<'a>(node: &'a DoWhileStmt, context: &mut Context<'a>) -> 
         items.push_str(" ");
     }
     items.extend(parse_node_in_parens((&node.test).into(), |context| parse_node((&node.test).into(), context), context));
-    if context.config.do_while_statement_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
     return items;
@@ -2672,7 +2663,7 @@ fn parse_export_all<'a>(node: &'a ExportAll, context: &mut Context<'a>) -> Print
     items.push_str("export * from ");
     items.extend(parse_node((&node.src).into(), context));
 
-    if context.config.export_all_declaration_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -2688,7 +2679,7 @@ fn parse_export_assignment<'a>(node: &'a TsExportAssignment, context: &mut Conte
 
     items.push_str("export = ");
     items.extend(parse_node((&node.expr).into(), context));
-    if context.config.export_assignment_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -2700,7 +2691,7 @@ fn parse_namespace_export<'a>(node: &'a TsNamespaceExportDecl, context: &mut Con
     items.push_str("export as namespace ");
     items.extend(parse_node((&node.id).into(), context));
 
-    if context.config.namespace_export_declaration_semi_colon {
+    if context.config.semi_colons.is_true() {
         items.push_str(";");
     }
 
@@ -2708,7 +2699,7 @@ fn parse_namespace_export<'a>(node: &'a TsNamespaceExportDecl, context: &mut Con
 }
 
 fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItems {
-    if context.config.expression_statement_semi_colon {
+    if context.config.semi_colons.is_true() {
         return parse_inner(&stmt, context);
     } else {
         return parse_for_prefix_semi_colon_insertion(&stmt, context);
@@ -2717,7 +2708,7 @@ fn parse_expr_stmt<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintIt
     fn parse_inner<'a>(stmt: &'a ExprStmt, context: &mut Context<'a>) -> PrintItems {
         let mut items = PrintItems::new();
         items.extend(parse_node((&stmt.expr).into(), context));
-        if context.config.expression_statement_semi_colon {
+        if context.config.semi_colons.is_true() {
             items.push_str(";");
         }
         return items;
@@ -3005,7 +2996,7 @@ fn parse_return_stmt<'a>(node: &'a ReturnStmt, context: &mut Context<'a>) -> Pri
         items.push_str(" ");
         items.extend(parse_node(arg.into(), context));
     }
-    if context.config.return_statement_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
     return items;
 }
 
@@ -3123,7 +3114,7 @@ fn parse_throw_stmt<'a>(node: &'a ThrowStmt, context: &mut Context<'a>) -> Print
     let mut items = PrintItems::new();
     items.push_str("throw ");
     items.extend(parse_node((&node.arg).into(), context));
-    if context.config.throw_statement_semi_colon { items.push_str(";"); }
+    if context.config.semi_colons.is_true() { items.push_str(";"); }
     return items;
 }
 
@@ -3221,7 +3212,7 @@ fn parse_var_decl<'a>(node: &'a VarDecl, context: &mut Context<'a>) -> PrintItem
             Node::ForInStmt(node) => var_decl_span.lo() >= node.body.span().lo(),
             Node::ForOfStmt(node) => var_decl_span.lo() >= node.body.span().lo(),
             Node::ForStmt(node) => var_decl_span.lo() >= node.body.span().lo(),
-            _ => context.config.variable_statement_semi_colon,
+            _ => context.config.semi_colons.is_true(),
         }
     }
 }
@@ -3458,7 +3449,7 @@ fn parse_mapped_type<'a>(node: &'a TsMappedType, context: &mut Context<'a>) -> P
             });
         }
         items.extend(parse_type_annotation_with_colon_if_exists_for_type(&node.type_ann, context));
-        if context.config.mapped_type_semi_colon {
+        if context.config.semi_colons.is_true() {
             items.push_str(";");
         }
         items

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -627,6 +627,7 @@ fn parse_class_decl_or_expr<'a>(node: ClassDeclOrExpr<'a>, context: &mut Context
             node_helpers::has_separating_blank_line(previous, next, context)
         },
         trailing_commas: None,
+        semi_colons: None,
     }, context));
 
     return items;
@@ -683,6 +684,7 @@ fn parse_enum_decl<'a>(node: &'a TsEnumDecl, context: &mut Context<'a>) -> Print
             }
         },
         trailing_commas: Some(context.config.enum_declaration_trailing_commas),
+        semi_colons: None,
     }, context));
 
     return items;
@@ -974,6 +976,7 @@ fn parse_module_or_namespace_decl<'a>(node: ModuleOrNamespaceDecl<'a>, context: 
                             node_helpers::has_separating_blank_line(previous, next, context)
                         },
                         trailing_commas: None,
+                        semi_colons: None,
                     }, context));
                 },
                 TsNamespaceBody::TsNamespaceDecl(decl) => {
@@ -1014,6 +1017,7 @@ fn parse_named_import_or_export_specifiers<'a>(parent: &Node<'a>, specifiers: Ve
         node_span: parent.span(),
         members: specifiers,
         trailing_commas: Some(TrailingCommas::Never),
+        semi_colons: None,
         prefer_hanging: get_prefer_hanging(&parent, context),
         surround_single_line_with_spaces: get_use_space(&parent, context),
     }, context);
@@ -1638,6 +1642,7 @@ fn parse_object_lit<'a>(node: &'a ObjectLit, context: &mut Context<'a>) -> Print
         node_span: node.span,
         members: node.props.iter().map(|x| x.into()).collect(),
         trailing_commas: Some(context.config.object_expression_trailing_commas),
+        semi_colons: None,
         prefer_hanging: context.config.object_expression_prefer_hanging,
         surround_single_line_with_spaces: true,
     }, context);
@@ -1659,6 +1664,7 @@ fn parse_sequence_expr<'a>(node: &'a SeqExpr, context: &mut Context<'a>) -> Prin
         prefer_hanging: true, // todo: config
         force_use_new_lines: false,
         trailing_commas: Some(TrailingCommas::Never),
+        semi_colons: None,
         surround_single_line_with_spaces: false,
     }, context)
 }
@@ -1907,7 +1913,6 @@ fn parse_call_signature_decl<'a>(node: &'a TsCallSignatureDecl, context: &mut Co
             type_node_separator: None,
         }, context)),
     }, context));
-    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -1929,7 +1934,6 @@ fn parse_construct_signature_decl<'a>(node: &'a TsConstructSignatureDecl, contex
             type_node_separator: None,
         }, context)),
     }, context));
-    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
 }
@@ -1944,33 +1948,8 @@ fn parse_index_signature<'a>(node: &'a TsIndexSignature, context: &mut Context<'
     items.extend(parse_node(node.params.iter().next().expect("Expected the index signature to have one parameter.").into(), context));
     items.push_str("]");
     items.extend(parse_type_annotation_with_colon_if_exists(&node.type_ann, context));
-    if context.config.semi_colons.is_true() { items.push_str(";"); }
 
     return items;
-}
-
-fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>) -> PrintItems {
-    let start_header_info = get_parent_info(context);
-
-    return parse_membered_body(ParseMemberedBodyOptions {
-        span: node.span,
-        members: node.body.iter().map(|x| x.into()).collect(),
-        start_header_info: start_header_info,
-        brace_position: context.config.interface_declaration_brace_position,
-        should_use_blank_line: move |previous, next, context| {
-            node_helpers::has_separating_blank_line(previous, next, context)
-        },
-        trailing_commas: None,
-    }, context);
-
-    fn get_parent_info(context: &mut Context) -> Option<Info> {
-        for ancestor in context.parent_stack.iter() {
-            if let Node::TsInterfaceDecl(ancestor) = ancestor {
-                return context.get_info_for_node(&ancestor).map(|x| x.to_owned());
-            }
-        }
-        return None;
-    }
 }
 
 fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context<'a>) -> PrintItems {
@@ -1994,8 +1973,6 @@ fn parse_method_signature<'a>(node: &'a TsMethodSignature, context: &mut Context
         }, context)),
     }, context));
 
-    if context.config.semi_colons.is_true() { items.push_str(";"); }
-
     return items;
 }
 
@@ -2018,9 +1995,32 @@ fn parse_property_signature<'a>(node: &'a TsPropertySignature, context: &mut Con
         }));
     }
 
-    if context.config.semi_colons.is_true() { items.push_str(";"); }
-
     return items;
+}
+
+fn parse_interface_body<'a>(node: &'a TsInterfaceBody, context: &mut Context<'a>) -> PrintItems {
+    let start_header_info = get_parent_info(context);
+
+    return parse_membered_body(ParseMemberedBodyOptions {
+        span: node.span,
+        members: node.body.iter().map(|x| x.into()).collect(),
+        start_header_info: start_header_info,
+        brace_position: context.config.interface_declaration_brace_position,
+        should_use_blank_line: move |previous, next, context| {
+            node_helpers::has_separating_blank_line(previous, next, context)
+        },
+        trailing_commas: None,
+        semi_colons: Some(context.config.semi_colons),
+    }, context);
+
+    fn get_parent_info(context: &mut Context) -> Option<Info> {
+        for ancestor in context.parent_stack.iter() {
+            if let Node::TsInterfaceDecl(ancestor) = ancestor {
+                return context.get_info_for_node(&ancestor).map(|x| x.to_owned());
+            }
+        }
+        return None;
+    }
 }
 
 fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> PrintItems {
@@ -2028,6 +2028,7 @@ fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> PrintIt
         node_span: node.span,
         members: node.members.iter().map(|m| m.into()).collect(),
         trailing_commas: None,
+        semi_colons: Some(context.config.type_literal_semi_colons),
         prefer_hanging: context.config.type_literal_prefer_hanging,
         surround_single_line_with_spaces: true,
     }, context);
@@ -2391,6 +2392,7 @@ fn parse_object_pat<'a>(node: &'a ObjectPat, context: &mut Context<'a>) -> Print
         node_span: node.span,
         members: node.props.iter().map(|x| x.into()).collect(),
         trailing_commas: Some(TrailingCommas::Never),
+        semi_colons: None,
         prefer_hanging: context.config.object_pattern_prefer_hanging,
         surround_single_line_with_spaces: true,
     }, context));
@@ -3021,6 +3023,7 @@ fn parse_switch_stmt<'a>(node: &'a SwitchStmt, context: &mut Context<'a>) -> Pri
             node_helpers::has_separating_blank_line(previous, next, context)
         },
         trailing_commas: None,
+        semi_colons: None,
     }, context));
     return items;
 }
@@ -3064,6 +3067,7 @@ fn parse_switch_case<'a>(node: &'a SwitchCase, context: &mut Context<'a>) -> Pri
                 should_use_new_line: None,
                 should_use_blank_line: |previous, next, context| node_helpers::has_separating_blank_line(previous, next, context),
                 trailing_commas: None,
+                semi_colons: None,
             }, context)));
         }
     }
@@ -3933,6 +3937,7 @@ fn parse_array_like_nodes<'a>(opts: ParseArrayLikeNodesOptions<'a>, context: &mu
         prefer_hanging: opts.prefer_hanging,
         force_use_new_lines,
         trailing_commas: Some(opts.trailing_commas),
+        semi_colons: None,
         surround_single_line_with_spaces: false,
     }, context));
     items.push_str("]");
@@ -3965,7 +3970,8 @@ struct ParseMemberedBodyOptions<'a, FShouldUseBlankLine> where FShouldUseBlankLi
     start_header_info: Option<Info>,
     brace_position: BracePosition,
     should_use_blank_line: FShouldUseBlankLine,
-    trailing_commas: Option<TrailingCommas>
+    trailing_commas: Option<TrailingCommas>,
+    semi_colons: Option<SemiColons>,
 }
 
 fn parse_membered_body<'a, FShouldUseBlankLine>(
@@ -4004,6 +4010,7 @@ fn parse_membered_body<'a, FShouldUseBlankLine>(
             should_use_new_line: None,
             should_use_blank_line: opts.should_use_blank_line,
             trailing_commas: opts.trailing_commas,
+            semi_colons: opts.semi_colons,
         }, context));
 
         items
@@ -4039,6 +4046,7 @@ fn parse_statements<'a>(inner_span: Span, stmts: impl Iterator<Item=Node<'a>>, c
         should_use_new_line: None,
         should_use_blank_line: |previous, next, context| node_helpers::has_separating_blank_line(previous, next, context),
         trailing_commas: None,
+        semi_colons: None,
     }, context)
 }
 
@@ -4049,6 +4057,7 @@ struct ParseStatementsOrMembersOptions<'a, FShouldUseBlankLine> where FShouldUse
     should_use_new_line: Option<Box<dyn Fn(&Node, &Node, &mut Context) -> bool>>,
     should_use_blank_line: FShouldUseBlankLine,
     trailing_commas: Option<TrailingCommas>,
+    semi_colons: Option<SemiColons>,
 }
 
 fn parse_statements_or_members<'a, FShouldUseBlankLine>(
@@ -4086,6 +4095,9 @@ fn parse_statements_or_members<'a, FShouldUseBlankLine>(
                 if let Some(trailing_commas) = opts.trailing_commas {
                     let parsed_comma = get_parsed_trailing_comma(trailing_commas, i == children_len - 1, &|_| Some(true));
                     parse_comma_separated_value(Some(node.clone()), parsed_comma, context)
+                } else if let Some(semi_colons) = opts.semi_colons {
+                    let parsed_semi_colon = get_parsed_semi_colon(semi_colons, i == children_len - 1, &|_| Some(true));
+                    parse_node_with_semi_colon(Some(node.clone()), parsed_semi_colon, context)
                 } else {
                     parse_node(node.clone(), context)
                 }
@@ -4144,6 +4156,7 @@ fn parse_parameters_or_arguments<'a, F>(opts: ParseParametersOrArgumentsOptions<
         prefer_hanging: opts.prefer_hanging,
         force_use_new_lines,
         trailing_commas: Some(TrailingCommas::Never),
+        semi_colons: None,
         surround_single_line_with_spaces: false,
     }, context));
 
@@ -4234,6 +4247,7 @@ struct ParseSeparatedValuesOptions<'a> {
     prefer_hanging: bool,
     force_use_new_lines: bool,
     trailing_commas: Option<TrailingCommas>,
+    semi_colons: Option<SemiColons>,
     surround_single_line_with_spaces: bool,
 }
 
@@ -4288,6 +4302,7 @@ fn parse_separated_values<'a>(
         nodes,
         is_multi_line_or_hanging.clone(),
         opts.trailing_commas,
+        opts.semi_colons,
         context
     );
     node_start_infos.borrow_mut().extend(inner_parse_result.item_start_infos);
@@ -4324,6 +4339,7 @@ fn parse_separated_values<'a>(
         nodes: Vec<Option<Node<'a>>>,
         is_multi_line_or_hanging: impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static,
         use_commas: Option<TrailingCommas>,
+        use_semi_colons: Option<SemiColons>,
         context: &mut Context<'a>
     ) -> InnerParseResult {
         let mut items = PrintItems::new();
@@ -4334,6 +4350,9 @@ fn parse_separated_values<'a>(
             let parsed_value = parser_helpers::new_line_group(if let Some(trailing_commas) = use_commas {
                 let parsed_comma = get_parsed_trailing_comma(trailing_commas, i == nodes_count - 1, &is_multi_line_or_hanging);
                 parse_comma_separated_value(value, parsed_comma, context)
+            } else if let Some(semi_colons) = use_semi_colons {
+                let parsed_semi_colon = get_parsed_semi_colon(semi_colons, i == nodes_count - 1, &is_multi_line_or_hanging);
+                parse_node_with_semi_colon(value, parsed_semi_colon, context)
             } else {
                 if let Some(value) = value {
                     parse_node(value, context)
@@ -4413,6 +4432,19 @@ fn parse_comma_separated_value<'a>(value: Option<Node<'a>>, parsed_comma: PrintI
             // todo: handle this
             None
         }
+    }
+}
+
+fn parse_node_with_semi_colon<'a>(value: Option<Node<'a>>, parsed_semi_colon: PrintItems, context: &mut Context<'a>) -> PrintItems {
+    if let Some(element) = value {
+        let parsed_semi_colon = parsed_semi_colon.into_rc_path();
+        parse_node_with_inner_parse(element, context, move |mut items| {
+            // this Rc clone is necessary because we can't move the captured parsed_semi_colon out of this closure
+            items.push_optional_path(parsed_semi_colon.clone());
+            items
+        })
+    } else {
+        parsed_semi_colon
     }
 }
 
@@ -4551,6 +4583,7 @@ struct ParseObjectLikeNodeOptions<'a> {
     node_span: Span,
     members: Vec<Node<'a>>,
     trailing_commas: Option<TrailingCommas>,
+    semi_colons: Option<SemiColons>,
     prefer_hanging: bool,
     surround_single_line_with_spaces: bool,
 }
@@ -4582,6 +4615,7 @@ fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mu
             should_use_new_line: None,
             should_use_blank_line: |previous, next, context| node_helpers::has_separating_blank_line(previous, next, context),
             trailing_commas: opts.trailing_commas,
+            semi_colons: opts.semi_colons,
         }, context)));
         items.push_signal(Signal::NewLine);
     } else {
@@ -4590,6 +4624,7 @@ fn parse_object_like_node<'a>(opts: ParseObjectLikeNodeOptions<'a>, context: &mu
             prefer_hanging: opts.prefer_hanging,
             force_use_new_lines: false,
             trailing_commas: opts.trailing_commas,
+            semi_colons: opts.semi_colons,
             surround_single_line_with_spaces: opts.surround_single_line_with_spaces,
         }, context));
     }
@@ -5206,6 +5241,7 @@ fn parse_jsx_children<'a>(opts: ParseJsxChildrenOptions<'a>, context: &mut Conte
                 return node_helpers::has_separating_blank_line(previous, next, context);
             },
             trailing_commas: None,
+            semi_colons: None,
         }, context)));
 
         if has_children {
@@ -5264,14 +5300,30 @@ fn get_parsed_trailing_comma(option: TrailingCommas, is_trailing: bool, is_multi
     match option {
         TrailingCommas::Always => ",".into(),
         TrailingCommas::OnlyMultiLine => {
-            Condition::new("trailingCommaIfMultiLine", ConditionProperties {
-                condition: Box::new(is_multi_line.clone()),
-                true_path: Some(",".into()),
-                false_path: None,
-            }).into()
+            if_true("trailingCommaIfMultiLine", is_multi_line.clone(), ",".into()).into()
         },
         TrailingCommas::Never => {
             PrintItems::new()
+        },
+    }
+}
+
+fn get_parsed_semi_colon(option: SemiColons, is_trailing: bool, is_multi_line: &(impl Fn(&mut ConditionResolverContext) -> Option<bool> + Clone + 'static)) -> PrintItems {
+    match option {
+        SemiColons::Always => ";".into(),
+        SemiColons::Prefer => {
+            if is_trailing {
+                if_true("semiColonIfMultiLine", is_multi_line.clone(), ";".into()).into()
+            } else {
+                ";".into()
+            }
+        },
+        SemiColons::Asi => {
+            if is_trailing {
+                PrintItems::new()
+            } else {
+                if_false("semiColonIfSingleLine", is_multi_line.clone(), ";".into()).into()
+            }
         },
     }
 }

--- a/packages/rust-dprint-plugin-typescript/src/parser.rs
+++ b/packages/rust-dprint-plugin-typescript/src/parser.rs
@@ -2028,7 +2028,7 @@ fn parse_type_lit<'a>(node: &'a TsTypeLit, context: &mut Context<'a>) -> PrintIt
         node_span: node.span,
         members: node.members.iter().map(|m| m.into()).collect(),
         trailing_commas: None,
-        semi_colons: Some(context.config.type_literal_semi_colons),
+        semi_colons: Some(context.config.semi_colons),
         prefer_hanging: context.config.type_literal_prefer_hanging,
         surround_single_line_with_spaces: true,
     }, context);

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/class/method/ClassMethod_DeclareMethod_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/class/method/ClassMethod_DeclareMethod_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ method.semiColon: false ~~
+~~ semiColons: asi ~~
 == should not use semi colons when specified not to ==
 abstract class Test {
     abstract method1(): string;

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/class/property/ClassProperty_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/class/property/ClassProperty_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ classProperty.semiColon: false ~~
+~~ semiColons: asi ~~
 == should not use a semi-colon when false ==
 class Test {
     prop: string;

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/export/ExportDefaultExpression_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/export/ExportDefaultExpression_SemiColons_Asi.txt
@@ -1,8 +1,8 @@
-~~ lineWidth: 40, exportDefaultExpression.semiColon: false ~~
+~~ lineWidth: 40, semiColons: asi ~~
 == should format without a semi-colon ==
 const test = 5;
 export    default   test;
 
 [expect]
-const test = 5;
+const test = 5
 export default test

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/export/ExportNamedDeclaration_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/export/ExportNamedDeclaration_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, exportNamedDeclaration.semiColon: false ~~
+~~ lineWidth: 40, semiColons: asi ~~
 == should format without semi-colons ==
 export {};
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/function/Function_All.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/function/Function_All.txt
@@ -71,7 +71,7 @@ function t({ a, b }: { a: string; b: number; }) {
 }
 
 [expect]
-function t({ a, b }: { a: string; b: number; }) {
+function t({ a, b }: { a: string; b: number }) {
 }
 
 == should force multi-line parameters when exceeding the line width ==

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/function/Function_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/function/Function_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ functionDeclaration.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without semi-colon ==
 declare function test(): string;
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/import/ImportDeclaration_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/import/ImportDeclaration_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ importDeclaration.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi colon ==
 import Test from "test";
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/importEquals/ImportEqualsDeclaration_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/importEquals/ImportEqualsDeclaration_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ importEqualsDeclaration.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi colon ==
 import a = require("t");
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/callSignature/CallSignature_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/callSignature/CallSignature_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ callSignature.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi-colon ==
 interface T {
     (): string;

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/constructSignature/ConstructSignature_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/constructSignature/ConstructSignature_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ constructSignature.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format ==
 type Test = {
     new(): string;
@@ -7,4 +7,4 @@ type Test = {
 [expect]
 type Test = {
     new(): string
-};
+}

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/indexSignature/IndexSignature_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/indexSignature/IndexSignature_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ indexSignature.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi-colon ==
 interface T {
     [index: number]: string;

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/methodSignature/MethodSignature_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/methodSignature/MethodSignature_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ methodSignature.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi-colon ==
 type T = {
     method(): string;
@@ -7,4 +7,4 @@ type T = {
 [expect]
 type T = {
     method(): string
-};
+}

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/propertySignature/PropertySignature_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/interface/propertySignature/PropertySignature_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ propertySignature.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format with no semi-colon ==
 type T = {
     p1   : string;
@@ -7,4 +7,4 @@ type T = {
 [expect]
 type T = {
     p1: string
-};
+}

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/module/ModuleDeclaration_NoBody_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/module/ModuleDeclaration_NoBody_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ moduleDeclaration.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi-colon ==
 declare module "testing";
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/declarations/namespaceExport/TSNamespaceExportDeclaration_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/declarations/namespaceExport/TSNamespaceExportDeclaration_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ namespaceExportDeclaration.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without semi-colon ==
 export   as   namespace   A;
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/breakStatement/BreakStatement_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/breakStatement/BreakStatement_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ breakStatement.semiColon: false ~~
+~~ semiColons: asi ~~
 == should not inclue a semi-colon ==
 for (let i = 0; i < 5; i++)
     break

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/continueStatement/ContinueStatement_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/continueStatement/ContinueStatement_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ continueStatement.semiColon: false ~~
+~~ semiColons: asi ~~
 == should not inclue a semi-colon ==
 for (let i = 0; i < 5; i++)
     continue

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/debuggerStatement/DebuggerStatement_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/debuggerStatement/DebuggerStatement_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ debuggerStatement.semiColon: false ~~
+~~ semiColons: asi ~~
 == should remove the semi-colon ==
 debugger;
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/exportAllDeclaration/ExportAllDeclaration_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/exportAllDeclaration/ExportAllDeclaration_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ exportAllDeclaration.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi-colon ==
 export  *  from   "test"  ;
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/exportAssignment/ExportAssignment_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/exportAssignment/ExportAssignment_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ exportAssignment.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi colon ==
 export = 5;
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/expressionStatement/ExpressionStatement_SemiColonInsertion.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/expressionStatement/ExpressionStatement_SemiColonInsertion.txt
@@ -1,4 +1,4 @@
-~~ expressionStatement.semiColon: false ~~
+~~ semiColons: asi ~~
 == should insert semi-colons at the start of lines beginning with a parenthesis ==
 (test);
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/expressionStatement/ExpressionStatement_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/expressionStatement/ExpressionStatement_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ expressionStatement.semiColon: false ~~
+~~ semiColons: asi ~~
 == should not output the semi colon ==
 testing.this();
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/forStatement/ForStatement_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/forStatement/ForStatement_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ semiColons: false ~~
+~~ semiColons: asi ~~
 == should use semi-colons regardless ==
 for (var i = 5; i < 5; i++) {
 }

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/returnStatement/ReturnStatement_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/returnStatement/ReturnStatement_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ returnStatement.semiColon: false ~~
+~~ semiColons: asi ~~
 == should remove the semi-colon when has argument ==
 function test() {
     return "test";

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/throwStatement/ThrowStatement_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/throwStatement/ThrowStatement_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ throwStatement.semiColon: false ~~
+~~ semiColons: asi ~~
 == should remove the semi-colon ==
 throw "test";
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/statements/variableStatement/VariableStatement_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/statements/variableStatement/VariableStatement_SemiColons_Asi.txt
@@ -1,4 +1,4 @@
-~~ variableStatement.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi-colon ==
 const a = 5;
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/types/MappedType/MappedType_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/types/MappedType/MappedType_SemiColons_Asi.txt
@@ -1,6 +1,6 @@
-~~ mappedType.semiColon: false ~~
+~~ semiColons: asi ~~
 == should format without a semi colon when configured to ==
 type Partial<T> = { [P in keyof T]?: T[P]; };
 
 [expect]
-type Partial<T> = { [P in keyof T]?: T[P] };
+type Partial<T> = { [P in keyof T]?: T[P] }

--- a/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_All.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_All.txt
@@ -6,11 +6,11 @@ type Test = {
 [expect]
 type Test = {};
 
-== should format when a single line ==
+== should format when a single line and not include a semi-colon on the last element ==
 type Test = { p: string; u: number; };
 
 [expect]
-type Test = { p: string; u: number; };
+type Test = { p: string; u: number };
 
 == should format when multi-line ==
 type Test = {
@@ -25,7 +25,7 @@ type Test = {
 };
 
 == should make multiple lines go multi-line ==
-type Test = { prop: string; other: number; };
+type Test = { prop: string; other: number };
 
 [expect]
 type Test = {

--- a/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_PreferHanging_True.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_PreferHanging_True.txt
@@ -3,7 +3,7 @@
 type Test = { p: string; u: number; };
 
 [expect]
-type Test = { p: string; u: number; };
+type Test = { p: string; u: number };
 
 == should format when multi-line ==
 type Test = {
@@ -22,7 +22,7 @@ type Test = { prop: string; other: number; };
 
 [expect]
 type Test = { prop: string;
-    other: number; };
+    other: number };
 
 == should respect multi-line ==
 type Test = {

--- a/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_SemiColons_Always.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_SemiColons_Always.txt
@@ -1,0 +1,18 @@
+~~ lineWidth: 40, typeLiteral.semiColons: always ~~
+== should have when a single line ==
+type Test = { p: string; u: number; };
+
+[expect]
+type Test = { p: string; u: number; };
+
+== should have when multi-line ==
+type Test = {
+    prop: string;
+    other: number;
+};
+
+[expect]
+type Test = {
+    prop: string;
+    other: number;
+};

--- a/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_SemiColons_Always.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_SemiColons_Always.txt
@@ -1,4 +1,4 @@
-~~ lineWidth: 40, typeLiteral.semiColons: always ~~
+~~ lineWidth: 40, semiColons: always ~~
 == should have when a single line ==
 type Test = { p: string; u: number; };
 

--- a/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_SemiColons_Asi.txt
@@ -1,0 +1,30 @@
+~~ lineWidth: 40, typeLiteral.semiColons: asi ~~
+== should have when a single line except on the last element ==
+type Test = { p: string; u: number; };
+
+[expect]
+type Test = { p: string; u: number };
+
+== should not have when multi-line ==
+type Test = {
+    prop: string;
+    other: number;
+};
+
+[expect]
+type Test = {
+    prop: string
+    other: number
+};
+
+== should be able to parse without semi-colon ==
+type Test = {
+    prop: string
+    other: number
+};
+
+[expect]
+type Test = {
+    prop: string
+    other: number
+};

--- a/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_SemiColons_Asi.txt
+++ b/packages/rust-dprint-plugin-typescript/tests/specs/types/TypeLiteral/TypeLiteral_SemiColons_Asi.txt
@@ -1,9 +1,9 @@
-~~ lineWidth: 40, typeLiteral.semiColons: asi ~~
+~~ lineWidth: 40, semiColons: asi ~~
 == should have when a single line except on the last element ==
 type Test = { p: string; u: number; };
 
 [expect]
-type Test = { p: string; u: number };
+type Test = { p: string; u: number }
 
 == should not have when multi-line ==
 type Test = {
@@ -15,7 +15,7 @@ type Test = {
 type Test = {
     prop: string
     other: number
-};
+}
 
 == should be able to parse without semi-colon ==
 type Test = {
@@ -27,4 +27,4 @@ type Test = {
 type Test = {
     prop: string
     other: number
-};
+}


### PR DESCRIPTION
Closes #102.

Changes `true`/`false` config to:

* `"always"` - Always uses semi-colons where applicable.
* `"prefer"` - Prefers to use semi-colons, but doesn't add one in certain scenarios such as for the last member of a single-line type literal (default).
* `"asi"` - Uses automatic semi-colon insertion. Only adds a semi-colon at the start of some expression statements when necessary. Read more: https://standardjs.com/rules.html#semicolons

Also, removed the joke of having semi-colon config per ast node.